### PR TITLE
Add ALIGN action to restore coherence and improve gameplay

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -44,7 +44,7 @@ export default function Home() {
           </p>
         </section>
 
-        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "2rem", marginBottom: "4rem" }}>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))", gap: "2rem", marginBottom: "4rem" }}>
           <div style={{ padding: "2rem", borderRadius: "16px", border: "1px solid #eaeaea", textAlign: "center" }}>
             <span style={{ fontSize: "0.8rem", textTransform: "uppercase", color: "#999", fontWeight: "bold" }}>Coherencia</span>
             <div style={{ fontSize: "3rem", fontWeight: "bold", margin: "0.5rem 0", color: state.coherence > 30 ? "#000" : "#ff0000" }}>
@@ -70,6 +70,20 @@ export default function Home() {
               style={{ width: "100%", padding: "0.75rem", borderRadius: "12px", backgroundColor: "#000", color: "#fff", border: "none", cursor: "pointer", fontWeight: "bold" }}
             >
               Reflejar
+            </button>
+          </div>
+
+          <div style={{ padding: "2rem", borderRadius: "16px", border: "1px solid #eaeaea", textAlign: "center" }}>
+            <span style={{ fontSize: "0.8rem", textTransform: "uppercase", color: "#999", fontWeight: "bold" }}>Alineación</span>
+            <div style={{ fontSize: "1.5rem", fontWeight: "bold", margin: "1.25rem 0", color: "#0070f3", height: "3rem", display: "flex", alignItems: "center", justifyContent: "center" }}>
+              {state.phase}
+            </div>
+            <button
+              onClick={() => dispatch("ALIGN")}
+              disabled={state.entropy <= 20 || state.phase === "COLLAPSED"}
+              style={{ width: "100%", padding: "0.75rem", borderRadius: "12px", backgroundColor: "#0070f3", color: "#fff", border: "none", cursor: "pointer", fontWeight: "bold", opacity: (state.entropy <= 20 || state.phase === "COLLAPSED") ? 0.5 : 1 }}
+            >
+              Alinear
             </button>
           </div>
         </div>

--- a/context/QuantumContext.tsx
+++ b/context/QuantumContext.tsx
@@ -5,7 +5,7 @@ import { QuantumSystemState, INITIAL_STATE, QuantumEngine } from "@/lib/quantum-
 
 interface QuantumContextType {
   state: QuantumSystemState;
-  dispatch: (action: "OBSERVE" | "REFLECT" | "RESET") => void;
+  dispatch: (action: "OBSERVE" | "REFLECT" | "RESET" | "ALIGN") => void;
   loading: boolean;
 }
 
@@ -34,7 +34,7 @@ export function QuantumProvider({ children }: { children: React.ReactNode }) {
     }
   }, [state, loading]);
 
-  const dispatch = useCallback((action: "OBSERVE" | "REFLECT" | "RESET") => {
+  const dispatch = useCallback((action: "OBSERVE" | "REFLECT" | "RESET" | "ALIGN") => {
     setState((prev) => QuantumEngine.transition(prev, action));
   }, []);
 

--- a/lib/quantum-engine.test.ts
+++ b/lib/quantum-engine.test.ts
@@ -1,0 +1,63 @@
+import { test, describe, it } from "node:test";
+import assert from "node:assert";
+import { QuantumEngine, INITIAL_STATE, QuantumSystemState } from "./quantum-engine";
+
+describe("QuantumEngine", () => {
+  it("should have initial state", () => {
+    assert.strictEqual(INITIAL_STATE.coherence, 100);
+    assert.strictEqual(INITIAL_STATE.entropy, 0);
+    assert.strictEqual(INITIAL_STATE.phase, "IDLE");
+  });
+
+  it("should increase entropy when OBSERVE is called", () => {
+    const newState = QuantumEngine.transition(INITIAL_STATE, "OBSERVE");
+    assert.strictEqual(newState.entropy, 2);
+    assert.strictEqual(newState.coherence, 99);
+    assert.strictEqual(newState.phase, "OBSERVING");
+    assert.strictEqual(newState.history.length, 2);
+  });
+
+  it("should decrease coherence significantly when REFLECT is called", () => {
+    // Need coherence > 20
+    const startState: QuantumSystemState = { ...INITIAL_STATE, coherence: 50 };
+    const newState = QuantumEngine.transition(startState, "REFLECT");
+    assert.strictEqual(newState.coherence, 45);
+    assert.strictEqual(newState.entropy, 5);
+    assert.strictEqual(newState.phase, "REFLECTING");
+    assert.strictEqual(newState.reflectionCount, 1);
+  });
+
+  it("should collapse if coherence drops to 0", () => {
+    const startState: QuantumSystemState = { ...INITIAL_STATE, coherence: 1 };
+    const newState = QuantumEngine.transition(startState, "OBSERVE");
+    // Coherence becomes 0
+    assert.strictEqual(newState.coherence, 0);
+    assert.strictEqual(newState.phase, "COLLAPSED");
+  });
+
+  it("should enter ENTANGLED phase if entropy > 50", () => {
+    const startState: QuantumSystemState = { ...INITIAL_STATE, entropy: 49 };
+    const newState = QuantumEngine.transition(startState, "OBSERVE");
+    // Entropy becomes 51
+    assert.strictEqual(newState.entropy, 51);
+    assert.strictEqual(newState.phase, "ENTANGLED");
+  });
+
+  it("should restore coherence and reduce entropy when ALIGN is called", () => {
+    // Need entropy > 20
+    const startState: QuantumSystemState = { ...INITIAL_STATE, entropy: 30, coherence: 50 };
+    const newState = QuantumEngine.transition(startState, "ALIGN");
+    assert.strictEqual(newState.entropy, 20); // 30 - 10
+    assert.strictEqual(newState.coherence, 55); // 50 + 5
+    assert.strictEqual(newState.phase, "ALIGNING");
+    assert.ok(newState.history[newState.history.length - 1].includes("Alineación"));
+  });
+
+  it("should do nothing when ALIGN is called if entropy <= 20", () => {
+    const startState: QuantumSystemState = { ...INITIAL_STATE, entropy: 20 };
+    const newState = QuantumEngine.transition(startState, "ALIGN");
+    assert.strictEqual(newState.entropy, 20);
+    assert.strictEqual(newState.phase, "IDLE"); // Should remain IDLE
+    assert.strictEqual(newState.history.length, startState.history.length);
+  });
+});

--- a/lib/quantum-engine.ts
+++ b/lib/quantum-engine.ts
@@ -1,4 +1,4 @@
-export type QuantumPhase = "IDLE" | "OBSERVING" | "REFLECTING" | "ENTANGLED" | "COLLAPSED";
+export type QuantumPhase = "IDLE" | "OBSERVING" | "REFLECTING" | "ENTANGLED" | "COLLAPSED" | "ALIGNING";
 
 export interface QuantumSystemState {
   phase: QuantumPhase;
@@ -19,7 +19,7 @@ export const INITIAL_STATE: QuantumSystemState = {
 };
 
 export class QuantumEngine {
-  static transition(state: QuantumSystemState, action: "OBSERVE" | "REFLECT" | "RESET"): QuantumSystemState {
+  static transition(state: QuantumSystemState, action: "OBSERVE" | "REFLECT" | "RESET" | "ALIGN"): QuantumSystemState {
     // ⚡ BOLT: Fix mutation bug by ensuring history is updated immutably
     const newState: QuantumSystemState = { ...state, lastUpdate: Date.now() };
 
@@ -44,6 +44,15 @@ export class QuantumEngine {
         }
         break;
 
+      case "ALIGN":
+        if (state.entropy > 20) {
+          newState.phase = "ALIGNING"; // This is a new phase, need to update QuantumPhase type too?
+          newState.entropy = Math.max(0, newState.entropy - 10);
+          newState.coherence = Math.min(100, newState.coherence + 5);
+          newState.history = [...state.history, "Alineación resonante. El caos se organiza."];
+        }
+        break;
+
       case "RESET":
         return { ...INITIAL_STATE, history: ["Sistema reiniciado manualmente."] };
     }
@@ -63,6 +72,7 @@ export class QuantumEngine {
   static getStatusMessage(state: QuantumSystemState): string {
     if (state.phase === "COLLAPSED") return "El espejo se ha quebrado. Reinicia para restaurar la armonía.";
     if (state.phase === "ENTANGLED") return "Estás entrelazado con el sistema. Tus acciones tienen consecuencias globales.";
+    if (state.phase === "ALIGNING") return "El sistema se reorganiza en armonía. La entropía disminuye.";
     if (state.coherence < 50) return "La señal es débil. El ruido está ganando.";
     return "Sistema estable. El espejo aguarda tu intención.";
   }


### PR DESCRIPTION
Implemented the 'ALIGN' action in 'lib/quantum-engine.ts' and exposed it via 'QuantumContext'.
Updated 'app/page.tsx' to display the current phase and provide an 'Alinear' button.
The button is enabled only when entropy is greater than 20.
Clicking it reduces entropy by 10 and increases coherence by 5, setting the phase to 'ALIGNING'.
This transforms the app from a linear decay simulation into a sustainable resource management game.
Verified with unit tests and frontend Playwright script.

---
*PR created automatically by Jules for task [17611746064490690413](https://jules.google.com/task/17611746064490690413) started by @mexicodxnmexico-create*