### PR TITLE
⚡ Bolt: Cap history array to prevent unbounded memory growth

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,7 @@
 ## 2025-02-05 - Efficient History Rendering
 **Learning:** Found that using `reverse()` on an array before mapping it in React causes O(n) computation and, more importantly, breaks key stability if using indices, leading to O(n) DOM updates.
 **Action:** Use `display: flex; flex-direction: column-reverse;` on the container to achieve visual reversal without array modification. Use absolute indices from the original array as keys to maintain stability, resulting in O(1) updates when new items are appended. Additionally, slice the history to a reasonable limit (e.g., last 50) to avoid DOM bloat.
+
+## 2025-02-06 - Unbounded State Growth
+**Learning:** Found that `QuantumSystemState.history` was allowed to grow indefinitely, leading to O(N) memory usage and O(N) serialization costs for `localStorage` persistence, which runs synchronously on the main thread.
+**Action:** Capped the history array to the last 100 items in `QuantumEngine.transition`. This ensures O(1) memory usage (capped at constant size) and constant-time serialization, preventing long-term performance degradation.

--- a/lib/quantum-engine.ts
+++ b/lib/quantum-engine.ts
@@ -57,6 +57,11 @@ export class QuantumEngine {
       newState.phase = "COLLAPSED";
     }
 
+    // ⚡ BOLT: Cap history to 100 items to prevent unbounded memory growth and improve serialization performance
+    if (newState.history.length > 100) {
+      newState.history = newState.history.slice(-100);
+    }
+
     return newState;
   }
 


### PR DESCRIPTION
⚡ **Bolt Performance Improvement**

**What:** Capped the `history` array in `QuantumSystemState` to a maximum of 100 items.
**Why:** The history array was growing indefinitely, causing O(N) memory usage and increasing the cost of `JSON.stringify` for `localStorage` persistence on every state change. This would eventually lead to performance degradation and potential crashes.
**Impact:** Ensures constant memory usage and serialization time for the history state, regardless of session length.
**Verification:** Verified with a reproduction test script (simulating 150 transitions) that history is correctly capped at 100. Verified frontend functionality remains intact via Playwright.

---
*PR created automatically by Jules for task [8328378655901937862](https://jules.google.com/task/8328378655901937862) started by @mexicodxnmexico-create*