### PR TITLE
⚡ Memoize QuantumContext value to prevent unnecessary re-renders

### DIFF
--- a/context/QuantumContext.tsx
+++ b/context/QuantumContext.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { createContext, useContext, useState, useEffect, useCallback } from "react";
+import React, { createContext, useContext, useState, useEffect, useCallback, useMemo } from "react";
 import { QuantumSystemState, INITIAL_STATE, QuantumEngine } from "@/lib/quantum-engine";
 
 interface QuantumContextType {
@@ -38,8 +38,10 @@ export function QuantumProvider({ children }: { children: React.ReactNode }) {
     setState((prev) => QuantumEngine.transition(prev, action));
   }, []);
 
+  const value = useMemo(() => ({ state, dispatch, loading }), [state, dispatch, loading]);
+
   return (
-    <QuantumContext.Provider value={{ state, dispatch, loading }}>
+    <QuantumContext.Provider value={value}>
       {children}
     </QuantumContext.Provider>
   );


### PR DESCRIPTION
💡 **What:**
Wrapped the context value object `{ state, dispatch, loading }` in `useMemo` within `QuantumProvider`.

🎯 **Why:**
Previously, a new object reference was created for the context value on every render of `QuantumProvider`, causing all context consumers to re-render even if `state`, `dispatch`, and `loading` had not changed. This optimization ensures that consumers only re-render when the actual state or loading status changes.

📊 **Measured Improvement:**
Explicit performance measurement (benchmarking) was skipped due to the absence of a configured component testing infrastructure (e.g., React Testing Library, Jest) in the current environment. However, `useMemo` for context values is a standard React performance best practice that guarantees referential stability and prevents wasted render cycles in consuming components.

Verified by:
- Manual code inspection to ensure correct dependency array `[state, dispatch, loading]`.
- `pnpm lint` (passed).
- `pnpm build` (passed).

---
*PR created automatically by Jules for task [17348556569398633805](https://jules.google.com/task/17348556569398633805) started by @mexicodxnmexico-create*