### PR TITLE
fix: ensure immutable history update in QuantumEngine

### DIFF
--- a/lib/quantum-engine.ts
+++ b/lib/quantum-engine.ts
@@ -20,8 +20,8 @@ export const INITIAL_STATE: QuantumSystemState = {
 
 export class QuantumEngine {
   static transition(state: QuantumSystemState, action: "OBSERVE" | "REFLECT" | "RESET"): QuantumSystemState {
-    // ⚡ BOLT: Fix mutation bug by ensuring history is updated immutably
-    const newState: QuantumSystemState = { ...state, lastUpdate: Date.now() };
+    // ⚡ BOLT: Ensure history is updated immutably by creating a shallow copy
+    const newState: QuantumSystemState = { ...state, history: [...state.history], lastUpdate: Date.now() };
 
     switch (action) {
       case "OBSERVE":


### PR DESCRIPTION
Explicitly clone the history array during state transition initialization to guarantee immutability, even for unhandled actions or future code changes.

---
*PR created automatically by Jules for task [5324913410307675382](https://jules.google.com/task/5324913410307675382) started by @mexicodxnmexico-create*