### PR TITLE
🎨 Palette: Accessible Onboarding Modal

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-11 - Accessible Modals: Beyond Visibility
+**Learning:** Custom modals implemented as `div` overlays are completely invisible to screen readers unless explicitly marked with `role="dialog"` and `aria-modal="true"`. Focusing the container on mount is crucial for context.
+**Action:** Always wrap custom modal content in a focusable container with correct ARIA roles and manage initial focus using `useEffect`.

--- a/components/Onboarding.tsx
+++ b/components/Onboarding.tsx
@@ -1,9 +1,15 @@
 "use client";
 
-import { useState, memo } from "react";
+import { useState, memo, useEffect, useRef } from "react";
 
 export const Onboarding = memo(function Onboarding({ onComplete }: { onComplete: () => void }) {
   const [step, setStep] = useState(0);
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // Focus the dialog when mounted so screen readers announce it
+    dialogRef.current?.focus();
+  }, []);
 
   const steps = [
     {
@@ -36,16 +42,25 @@ export const Onboarding = memo(function Onboarding({ onComplete }: { onComplete:
       zIndex: 1000,
       padding: "1rem"
     }}>
-      <div style={{
-        backgroundColor: "white",
-        padding: "2.5rem",
-        borderRadius: "16px",
-        maxWidth: "500px",
-        width: "100%",
-        textAlign: "center"
-      }}>
-        <h2 style={{ marginBottom: "1rem", fontSize: "1.5rem" }}>{steps[step].title}</h2>
-        <p style={{ color: "#666", lineHeight: "1.6", marginBottom: "2rem" }}>{steps[step].content}</p>
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="onboarding-title"
+        aria-describedby="onboarding-desc"
+        tabIndex={-1}
+        style={{
+          backgroundColor: "white",
+          padding: "2.5rem",
+          borderRadius: "16px",
+          maxWidth: "500px",
+          width: "100%",
+          textAlign: "center",
+          outline: "none"
+        }}
+      >
+        <h2 id="onboarding-title" style={{ marginBottom: "1rem", fontSize: "1.5rem" }}>{steps[step].title}</h2>
+        <p id="onboarding-desc" style={{ color: "#666", lineHeight: "1.6", marginBottom: "2rem" }}>{steps[step].content}</p>
         <button
           onClick={() => {
             if (step === steps.length - 1) {


### PR DESCRIPTION
💡 What: Added ARIA attributes (role="dialog", aria-modal="true", aria-labelledby) and focus management to the Onboarding modal.
🎯 Why: Custom modals were invisible to screen readers, violating WCAG guidelines and confusing users relying on assistive technology.
📸 Before/After: Visual appearance unchanged, but screen reader experience is now functional.
♿ Accessibility: Modal now announces itself as a dialog, reads the title, and manages focus on mount.

---
*PR created automatically by Jules for task [17388395698636555392](https://jules.google.com/task/17388395698636555392) started by @mexicodxnmexico-create*