### PR TITLE
⚡ Bolt: Debounce localStorage writes

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -11,3 +11,7 @@
 ## 2025-02-06 - Unbounded State Growth
 **Learning:** The `QuantumSystemState.history` array was growing indefinitely, causing increased memory usage and slower `localStorage` serialization (blocking the main thread) as the session duration increased.
 **Action:** Cap the history array to a fixed size (e.g., 100 items) within the state transition logic to ensure constant-time (O(1)) memory usage and serialization performance, regardless of session length.
+
+## 2025-02-07 - Synchronous Storage Blocking
+**Learning:** `localStorage.setItem` is synchronous and blocks the main thread. When tied directly to state updates in a `useEffect`, rapid state changes (like clicking "Observe") cause frame drops. The existing implementation was believed to be debounced but was actually synchronous.
+**Action:** Implement a 500ms debounce in `QuantumProvider` using `setTimeout` inside `useEffect` to batch writes and unblock the UI thread during rapid interactions.

--- a/context/QuantumContext.tsx
+++ b/context/QuantumContext.tsx
@@ -30,7 +30,17 @@ export function QuantumProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     if (!loading) {
-      localStorage.setItem("quantum_state_v2", JSON.stringify(state));
+      // ⚡ BOLT OPTIMIZATION: Debounce localStorage writes by 500ms
+      // to avoid blocking the main thread with synchronous I/O on every state update.
+      const timer = setTimeout(() => {
+        try {
+          localStorage.setItem("quantum_state_v2", JSON.stringify(state));
+        } catch (e) {
+          console.error("Failed to save quantum state", e);
+        }
+      }, 500);
+
+      return () => clearTimeout(timer);
     }
   }, [state, loading]);
 


### PR DESCRIPTION
💡 What: Implemented a 500ms debounce on `localStorage.setItem` in `QuantumProvider`.

🎯 Why: Synchronous storage writes block the main thread. Rapid state updates (e.g. clicking "Observe") were causing frame drops due to repeated blocking I/O. The existing implementation was mistakenly thought to be debounced but was actually synchronous.

📊 Impact: Reduces blocking main thread time during rapid interactions. Batches multiple state updates into a single write.

🔬 Measurement: Verified that writes are delayed and coalesced, improving UI responsiveness during heavy interaction bursts.

---
*PR created automatically by Jules for task [4078193734062810586](https://jules.google.com/task/4078193734062810586) started by @mexicodxnmexico-create*