### PR TITLE
⚡ Bolt: Debounce localStorage writes in QuantumContext

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -11,3 +11,7 @@
 ## 2025-02-06 - Unbounded State Growth
 **Learning:** The `QuantumSystemState.history` array was growing indefinitely, causing increased memory usage and slower `localStorage` serialization (blocking the main thread) as the session duration increased.
 **Action:** Cap the history array to a fixed size (e.g., 100 items) within the state transition logic to ensure constant-time (O(1)) memory usage and serialization performance, regardless of session length.
+
+## 2025-02-07 - Synchronous Storage Blocking
+**Learning:** `localStorage.setItem` is synchronous and blocks the main thread. In `QuantumContext`, it was called on every state update, causing UI jank during rapid interactions.
+**Action:** Implemented a debounce (500ms) for persistence and added a `beforeunload` listener to ensure data integrity on tab close.


### PR DESCRIPTION
*   💡 What: Added a 500ms debounce to `localStorage.setItem` in `QuantumContext.tsx` and a `beforeunload` listener for data integrity.
*   🎯 Why: Synchronous `localStorage` writes were blocking the main thread on every state update, causing potential UI jank during rapid interactions.
*   📊 Impact: Reduces main thread blocking time significantly during frequent state changes.
*   🔬 Measurement: Verified by code review and passing existing tests. Verified with manual reasoning about event loop and storage API behavior.

---
*PR created automatically by Jules for task [14820185938490813806](https://jules.google.com/task/14820185938490813806) started by @mexicodxnmexico-create*