### PR TITLE
⚡ Bolt: Debounce localStorage writes

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -11,3 +11,7 @@
 ## 2025-02-06 - Unbounded State Growth
 **Learning:** The `QuantumSystemState.history` array was growing indefinitely, causing increased memory usage and slower `localStorage` serialization (blocking the main thread) as the session duration increased.
 **Action:** Cap the history array to a fixed size (e.g., 100 items) within the state transition logic to ensure constant-time (O(1)) memory usage and serialization performance, regardless of session length.
+
+## 2025-02-07 - Synchronous Storage Blocking
+**Learning:** Found that `localStorage.setItem` inside a `useEffect` triggered by frequent state changes causes main thread blocking. Debouncing this operation significantly improves responsiveness, but requires a `beforeunload` listener (using a `ref` for the latest state) to prevent data loss on tab closure.
+**Action:** Use `useRef` to store state and timeout IDs, and always pair debounced persistence with a `beforeunload` handler.

--- a/context/QuantumContext.tsx
+++ b/context/QuantumContext.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { createContext, useContext, useState, useEffect, useCallback } from "react";
+import React, { createContext, useContext, useState, useEffect, useCallback, useRef } from "react";
 import { QuantumSystemState, INITIAL_STATE, QuantumEngine } from "@/lib/quantum-engine";
 
 interface QuantumContextType {
@@ -28,11 +28,57 @@ export function QuantumProvider({ children }: { children: React.ReactNode }) {
     setLoading(false);
   }, []);
 
+  // ⚡ BOLT OPTIMIZATION: Debounce localStorage writes (500ms) to prevent main thread blocking
+  // on every state update, while ensuring data safety with beforeunload.
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const stateRef = useRef(state);
+
+  // Keep stateRef in sync for the event listener without re-binding it
   useEffect(() => {
-    if (!loading) {
-      localStorage.setItem("quantum_state_v2", JSON.stringify(state));
+    stateRef.current = state;
+  }, [state]);
+
+  // Debounced save effect
+  useEffect(() => {
+    if (loading) return;
+
+    // Clear any pending save
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
     }
+
+    // Schedule new save
+    timeoutRef.current = setTimeout(() => {
+      try {
+        localStorage.setItem("quantum_state_v2", JSON.stringify(state));
+      } catch (e) {
+        console.error("Failed to save quantum state", e);
+      }
+    }, 500);
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
   }, [state, loading]);
+
+  // Immediate save on unload to prevent data loss
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      if (!loading) {
+        try {
+          // Use ref to get latest state without adding state as dependency
+          localStorage.setItem("quantum_state_v2", JSON.stringify(stateRef.current));
+        } catch (e) {
+          console.error("Failed to save quantum state on unload", e);
+        }
+      }
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [loading]);
 
   const dispatch = useCallback((action: "OBSERVE" | "REFLECT" | "RESET") => {
     setState((prev) => QuantumEngine.transition(prev, action));


### PR DESCRIPTION
💡 What: Added a 500ms debounce to localStorage.setItem calls in QuantumContext and implemented a beforeunload listener for data safety.
🎯 Why: Writing to localStorage is synchronous and was blocking the main thread on every state update, causing potential jank during rapid interactions.
📊 Impact: Reduces main thread blocking time significantly during high-frequency updates.
🔬 Measurement: Verified with unit tests and build checks.

---
*PR created automatically by Jules for task [15576731067881486208](https://jules.google.com/task/15576731067881486208) started by @mexicodxnmexico-create*