### PR TITLE
⚡ Bolt: Debounce localStorage persistence

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -11,3 +11,7 @@
 ## 2025-02-06 - Unbounded State Growth
 **Learning:** The `QuantumSystemState.history` array was growing indefinitely, causing increased memory usage and slower `localStorage` serialization (blocking the main thread) as the session duration increased.
 **Action:** Cap the history array to a fixed size (e.g., 100 items) within the state transition logic to ensure constant-time (O(1)) memory usage and serialization performance, regardless of session length.
+
+## 2025-02-07 - Synchronous Storage Blocking
+**Learning:** `localStorage.setItem` is synchronous and can block the main thread, especially when serializing large state objects (`JSON.stringify`) on every state update. In high-frequency interaction apps, this causes noticeable jank.
+**Action:** Implement a debounce (e.g., 500ms) for persistence operations to unblock the main thread, and use a `beforeunload` listener with a ref to the latest state to ensure data safety on exit.

--- a/context/QuantumContext.tsx
+++ b/context/QuantumContext.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { createContext, useContext, useState, useEffect, useCallback } from "react";
+import React, { createContext, useContext, useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { QuantumSystemState, INITIAL_STATE, QuantumEngine } from "@/lib/quantum-engine";
 
 interface QuantumContextType {
@@ -15,7 +15,14 @@ export function QuantumProvider({ children }: { children: React.ReactNode }) {
   const [state, setState] = useState<QuantumSystemState>(INITIAL_STATE);
   const [loading, setLoading] = useState(true);
 
-  // Persistence (Addressing "memory" requirement)
+  // ⚡ BOLT: Keep a ref of the latest state for the beforeunload listener
+  // This avoids re-binding the listener on every state change.
+  const stateRef = useRef(state);
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+
+  // Initial load
   useEffect(() => {
     const saved = localStorage.getItem("quantum_state_v2");
     if (saved) {
@@ -28,18 +35,47 @@ export function QuantumProvider({ children }: { children: React.ReactNode }) {
     setLoading(false);
   }, []);
 
+  // ⚡ BOLT: Debounce localStorage writes to avoid blocking the main thread
+  // on every interaction. Wait 500ms before saving.
   useEffect(() => {
-    if (!loading) {
-      localStorage.setItem("quantum_state_v2", JSON.stringify(state));
-    }
+    if (loading) return;
+
+    const timeoutId = setTimeout(() => {
+      try {
+        localStorage.setItem("quantum_state_v2", JSON.stringify(state));
+      } catch (e) {
+        console.error("Failed to save state:", e);
+      }
+    }, 500);
+
+    return () => clearTimeout(timeoutId);
   }, [state, loading]);
+
+  // ⚡ BOLT: Save immediately on tab close to prevent data loss
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      if (!loading && stateRef.current) {
+        try {
+          localStorage.setItem("quantum_state_v2", JSON.stringify(stateRef.current));
+        } catch (e) {
+          console.error("Failed to save state on unload:", e);
+        }
+      }
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [loading]);
 
   const dispatch = useCallback((action: "OBSERVE" | "REFLECT" | "RESET") => {
     setState((prev) => QuantumEngine.transition(prev, action));
   }, []);
 
+  // ⚡ BOLT: Memoize provider value to prevent unnecessary re-renders
+  const value = useMemo(() => ({ state, dispatch, loading }), [state, dispatch, loading]);
+
   return (
-    <QuantumContext.Provider value={{ state, dispatch, loading }}>
+    <QuantumContext.Provider value={value}>
       {children}
     </QuantumContext.Provider>
   );


### PR DESCRIPTION
*   💡 **What:** Implemented a 500ms debounce for `localStorage.setItem` in `QuantumContext` and added a `beforeunload` listener for data safety. Also memoized the context value.
*   🎯 **Why:** Synchronous `localStorage` writes block the main thread on every state update, causing jank during rapid interactions.
*   📊 **Impact:** Unblocks the main thread during gameplay, improving responsiveness. Prevents unnecessary re-renders of context consumers.
*   🔬 **Measurement:** Verify by spamming "Observar" and checking Performance tab (no long tasks from `setItem`). Verify data persistence by closing tab immediately.

---
*PR created automatically by Jules for task [15882717354551044658](https://jules.google.com/task/15882717354551044658) started by @mexicodxnmexico-create*