### PR TITLE
⚡ Bolt: optimize QuantumProvider persistence and memoization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -11,3 +11,7 @@
 ## 2025-02-06 - Unbounded State Growth
 **Learning:** The `QuantumSystemState.history` array was growing indefinitely, causing increased memory usage and slower `localStorage` serialization (blocking the main thread) as the session duration increased.
 **Action:** Cap the history array to a fixed size (e.g., 100 items) within the state transition logic to ensure constant-time (O(1)) memory usage and serialization performance, regardless of session length.
+
+## 2025-02-13 - Debounced Persistence and Data Integrity
+**Learning:** Implementing debounced `localStorage` persistence significantly reduces main-thread blocking during rapid state updates, but requires a `beforeunload` listener with a state reference (`useRef`) to ensure data integrity on tab closure.
+**Action:** Always pair debounced persistence with an immediate save on `beforeunload` using the latest state ref.

--- a/context/QuantumContext.tsx
+++ b/context/QuantumContext.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { createContext, useContext, useState, useEffect, useCallback } from "react";
+import React, { createContext, useContext, useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { QuantumSystemState, INITIAL_STATE, QuantumEngine } from "@/lib/quantum-engine";
 
 interface QuantumContextType {
@@ -14,6 +14,8 @@ const QuantumContext = createContext<QuantumContextType | undefined>(undefined);
 export function QuantumProvider({ children }: { children: React.ReactNode }) {
   const [state, setState] = useState<QuantumSystemState>(INITIAL_STATE);
   const [loading, setLoading] = useState(true);
+  const stateRef = useRef(state);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Persistence (Addressing "memory" requirement)
   useEffect(() => {
@@ -28,18 +30,56 @@ export function QuantumProvider({ children }: { children: React.ReactNode }) {
     setLoading(false);
   }, []);
 
+  // Update ref to latest state for beforeunload handler
   useEffect(() => {
-    if (!loading) {
-      localStorage.setItem("quantum_state_v2", JSON.stringify(state));
+    stateRef.current = state;
+  }, [state]);
+
+  // ⚡ BOLT: Debounce localStorage persistence to 500ms to reduce main thread blocking
+  useEffect(() => {
+    if (loading) return;
+
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
     }
+
+    timeoutRef.current = setTimeout(() => {
+      try {
+        localStorage.setItem("quantum_state_v2", JSON.stringify(state));
+      } catch (e) {
+        console.error("Failed to save state to localStorage", e);
+      }
+    }, 500);
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
   }, [state, loading]);
+
+  // ⚡ BOLT: Immediate save on tab closure to prevent data loss from debounce
+  useEffect(() => {
+    const handleUnload = () => {
+      try {
+        localStorage.setItem("quantum_state_v2", JSON.stringify(stateRef.current));
+      } catch (e) {
+        console.error("Failed to save state on unload", e);
+      }
+    };
+    window.addEventListener("beforeunload", handleUnload);
+    return () => window.removeEventListener("beforeunload", handleUnload);
+  }, []);
 
   const dispatch = useCallback((action: "OBSERVE" | "REFLECT" | "RESET") => {
     setState((prev) => QuantumEngine.transition(prev, action));
   }, []);
 
+  // ⚡ BOLT: Memoize provider value to prevent unnecessary re-renders of consumers
+  const value = useMemo(() => ({ state, dispatch, loading }), [state, dispatch, loading]);
+
   return (
-    <QuantumContext.Provider value={{ state, dispatch, loading }}>
+    <QuantumContext.Provider value={value}>
       {children}
     </QuantumContext.Provider>
   );


### PR DESCRIPTION
💡 What: Optimized the `QuantumProvider` in `context/QuantumContext.tsx` by implementing debounced state persistence and memoizing the context value.

🎯 Why: 
1. Frequent synchronous `localStorage.setItem` and `JSON.stringify` calls on every state change were potentially blocking the main thread, especially as the session history grew.
2. The context provider was passing a new object literal on every render, causing all consumer components to re-render unnecessarily.

📊 Impact:
- Reduces `localStorage` write frequency significantly during rapid user interaction (e.g., clicking "Observe" or "Reflect").
- Ensures O(1) re-render cost for context consumers that don't depend on the state itself (by stabilizing the `dispatch` and `loading` references).
- Maintains data integrity with an immediate save on page unload.

🔬 Measurement:
- Verified that state is correctly persisted across page reloads using Playwright.
- Verified that immediate reloads (before the 500ms debounce) still save the latest state via the `beforeunload` listener.
- Ensured no regressions in core logic via existing unit tests.

---
*PR created automatically by Jules for task [16626262152511366903](https://jules.google.com/task/16626262152511366903) started by @mexicodxnmexico-create*