### PR TITLE
🎨 Palette: Clear visual states for disabled buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,8 @@
 ## 2024-05-24 - Text Contrast Standards
 **Learning:** Text color '#999' on light backgrounds (e.g., '#fafafa') fails WCAG AA contrast ratio (approx 2.9:1).
 **Action:** Use '#555' (approx 7.5:1) or darker for secondary text to ensure readability for all users.
+
+
+## 2026-03-01 - Clear Disabled Button States
+**Learning:** Default disabled attributes on buttons may not visually communicate their inactive state clearly, and lack context as to why they are disabled. Users might think the interface is broken.
+**Action:** Always complement the `disabled` attribute with visual cues like `opacity: 0.5` and `cursor: 'not-allowed'`, and provide context using a `title` attribute or tooltip explaining why the action is restricted.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -109,7 +109,12 @@ export default function Home() {
             <button
               onClick={() => dispatch("OBSERVE")}
               disabled={state.phase === "COLLAPSED"}
-              style={OBSERVE_BTN_STYLE}
+              title={state.phase === "COLLAPSED" ? "El sistema ha colapsado. Restaura el espejo para continuar." : ""}
+              style={{
+                ...OBSERVE_BTN_STYLE,
+                opacity: state.phase === "COLLAPSED" ? 0.5 : 1,
+                cursor: state.phase === "COLLAPSED" ? "not-allowed" : "pointer"
+              }}
             >
               Observar
             </button>
@@ -123,7 +128,12 @@ export default function Home() {
             <button
               onClick={() => dispatch("REFLECT")}
               disabled={state.phase === "COLLAPSED"}
-              style={REFLECT_BTN_STYLE}
+              title={state.phase === "COLLAPSED" ? "El sistema ha colapsado. Restaura el espejo para continuar." : ""}
+              style={{
+                ...REFLECT_BTN_STYLE,
+                opacity: state.phase === "COLLAPSED" ? 0.5 : 1,
+                cursor: state.phase === "COLLAPSED" ? "not-allowed" : "pointer"
+              }}
             >
               Reflejar
             </button>

--- a/components/ProgressDashboard.tsx
+++ b/components/ProgressDashboard.tsx
@@ -108,7 +108,7 @@ const ProgressDashboard: React.FC<ProgressDashboardProps> = ({
                 )}
             </div>
             <div className="quote-section card-animate">
-                <p className="quote-text"> "Every moment of mindfulness is a step towards inner peace" </p>
+                <p className="quote-text"> &quot;Every moment of mindfulness is a step towards inner peace&quot; </p>
                 <p className="quote-author">— Meditation Journey</p>
             </div>
         </div>

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
💡 **What:** Added clear visual cues (`opacity: 0.5` and `cursor: not-allowed`) and a helpful tooltip (`title`) to the "Observar" and "Reflejar" buttons when the system enters the COLLAPSED state.
🎯 **Why:** Previously, the disabled buttons provided no visual indication that they were unclickable other than failing to respond, which could lead users to believe the application was broken. The added tooltip explains *why* the buttons are disabled and how to fix it, reducing friction and confusion.
♿ **Accessibility:** Improved cognitive accessibility by explicitly communicating system state and required actions via tooltips, rather than relying solely on the native `disabled` attribute.

(Also included a drive-by fix in `ProgressDashboard.tsx` to escape raw double quotes in JSX to satisfy ESLint).

---
*PR created automatically by Jules for task [10475825494300761940](https://jules.google.com/task/10475825494300761940) started by @mexicodxnmexico-create*