### PR TITLE
🎨 Palette: Visual disabled states for action buttons

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -109,7 +109,8 @@ export default function Home() {
             <button
               onClick={() => dispatch("OBSERVE")}
               disabled={state.phase === "COLLAPSED"}
-              style={OBSERVE_BTN_STYLE}
+              style={state.phase === "COLLAPSED" ? { ...OBSERVE_BTN_STYLE, opacity: 0.5, cursor: "not-allowed" } : OBSERVE_BTN_STYLE}
+              title={state.phase === "COLLAPSED" ? "El sistema está colapsado. Restaure el espejo primero." : undefined}
             >
               Observar
             </button>
@@ -123,7 +124,8 @@ export default function Home() {
             <button
               onClick={() => dispatch("REFLECT")}
               disabled={state.phase === "COLLAPSED"}
-              style={REFLECT_BTN_STYLE}
+              style={state.phase === "COLLAPSED" ? { ...REFLECT_BTN_STYLE, opacity: 0.5, cursor: "not-allowed" } : REFLECT_BTN_STYLE}
+              title={state.phase === "COLLAPSED" ? "El sistema está colapsado. Restaure el espejo primero." : undefined}
             >
               Reflejar
             </button>


### PR DESCRIPTION
💡 **What**: Added explicit visual disabled states (`opacity: 0.5`, `cursor: not-allowed`) and explanatory tooltips (`title` attributes) to the "Observar" and "Reflejar" buttons when the system is in a "COLLAPSED" state.

🎯 **Why**: When the system collapsed, the buttons became functionally disabled, but visually they still appeared active. This causes a confusing user experience because users might repeatedly click a button that looks active but does nothing. Adding a visual cue and an explanation helps the user understand the system's state and what to do next.

📸 **Before/After**: The buttons now appear faded out and display a "not-allowed" cursor on hover, along with a tooltip that says: "El sistema está colapsado. Restaure el espejo primero."

♿ **Accessibility**: Improves clarity for screen readers and keyboard users by providing a `title` attribute that explicitly explains the disabled state condition, rather than just announcing "disabled" with no context.

---
*PR created automatically by Jules for task [9198311967304614644](https://jules.google.com/task/9198311967304614644) started by @mexicodxnmexico-create*