### PR TITLE
🧪 Test COLLAPSED state transitions in QuantumEngine

### DIFF
--- a/lib/quantum-engine.test.ts
+++ b/lib/quantum-engine.test.ts
@@ -28,3 +28,21 @@ test('History should keep the most recent items when capped', (t) => {
     assert.strictEqual(state.history[0], "Older 2");
     assert.strictEqual(state.history[99], "Observación registrada. La entropía aumenta.");
 });
+
+test('Engine should transition to COLLAPSED state when coherence drops to 0 or below', (t) => {
+    let state = { ...INITIAL_STATE, coherence: 1 };
+
+    // Perform transition that reduces coherence by 1
+    state = QuantumEngine.transition(state, "OBSERVE");
+
+    assert.strictEqual(state.coherence, 0, 'Coherence should be 0');
+    assert.strictEqual(state.phase, 'COLLAPSED', 'Phase should transition to COLLAPSED when coherence is <= 0');
+
+    // Test going below 0 (though logic caps at 0, if it was possible)
+    let stateBelow0 = { ...INITIAL_STATE, coherence: 0 };
+    // Force coherence to something negative before secondary rules
+    // (We test REFLECT with coherence <= 20 since it goes directly to COLLAPSED)
+    let stateReflectCollapse = QuantumEngine.transition({ ...INITIAL_STATE, coherence: 20 }, "REFLECT");
+
+    assert.strictEqual(stateReflectCollapse.phase, 'COLLAPSED', 'Phase should transition to COLLAPSED directly via REFLECT on low coherence');
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR adds a unit test for the `COLLAPSED` state transition logic in `QuantumEngine`. Previously, there were no explicit checks ensuring that `QuantumEngine.transition()` correctly evaluated and transitioned the system phase to `"COLLAPSED"` when `coherence` reached 0 or dropped below it.

📊 **Coverage:** What scenarios are now tested
- Validates the primary condition where calling `OBSERVE` lowers `coherence` to exactly `0`, verifying that the resulting state's `coherence` is `0` and `phase` transitions to `"COLLAPSED"`.
- Validates a secondary condition where `coherence` is below the threshold required for `REFLECT` (e.g., `<= 20`), ensuring a direct transition to the `"COLLAPSED"` state without waiting for the secondary rules.

✨ **Result:** The improvement in test coverage
Increased the overall robustness of the `QuantumEngine` by adding safety nets around its most critical failure state (`COLLAPSED`). Refactoring or optimizing state logic will now confidently alert developers if these vital constraints are broken.

---
*PR created automatically by Jules for task [14074340463616192190](https://jules.google.com/task/14074340463616192190) started by @mexicodxnmexico-create*