### PR TITLE
🧪 Add test for RESET action in QuantumEngine

### DIFF
--- a/lib/quantum-engine.test.ts
+++ b/lib/quantum-engine.test.ts
@@ -28,3 +28,32 @@ test('History should keep the most recent items when capped', (t) => {
     assert.strictEqual(state.history[0], "Older 2");
     assert.strictEqual(state.history[99], "Observación registrada. La entropía aumenta.");
 });
+
+test('RESET action should reset state and set correct history', (t) => {
+  let state = { ...INITIAL_STATE };
+
+  // Transition to a non-initial state
+  state = QuantumEngine.transition(state, "OBSERVE");
+  state = QuantumEngine.transition(state, "REFLECT");
+
+  // Verify state is not initial
+  assert.notStrictEqual(state.coherence, INITIAL_STATE.coherence);
+  assert.notStrictEqual(state.entropy, INITIAL_STATE.entropy);
+  assert.notStrictEqual(state.phase, INITIAL_STATE.phase);
+
+  // Apply RESET
+  const resetState = QuantumEngine.transition(state, "RESET");
+
+  // Verify reset state matches INITIAL_STATE (except for history and lastUpdate)
+  assert.strictEqual(resetState.coherence, INITIAL_STATE.coherence);
+  assert.strictEqual(resetState.entropy, INITIAL_STATE.entropy);
+  assert.strictEqual(resetState.phase, INITIAL_STATE.phase);
+  assert.strictEqual(resetState.reflectionCount, INITIAL_STATE.reflectionCount);
+
+  // Verify history is set correctly
+  assert.strictEqual(resetState.history.length, 1);
+  assert.strictEqual(resetState.history[0], "Sistema reiniciado manualmente.");
+
+  // lastUpdate should be greater than or equal to INITIAL_STATE.lastUpdate
+  assert.ok(resetState.lastUpdate >= INITIAL_STATE.lastUpdate);
+});

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,3 @@
+🎯 **What:** The `RESET` action in `QuantumEngine.transition` was previously untested, leaving a coverage gap for this critical edge case.
+📊 **Coverage:** The new test validates that when `RESET` is invoked on a modified state, it correctly clears accumulated entropy, resets coherence, returns the phase to `IDLE`, and assigns the specific `"Sistema reiniciado manualmente."` history message, while also verifying that `lastUpdate` is correctly updated.
+✨ **Result:** Test coverage for `QuantumEngine` is improved, ensuring reliability when resetting the system.


### PR DESCRIPTION
🎯 **What:** The `RESET` action in `QuantumEngine.transition` was previously untested, leaving a coverage gap for this critical edge case.
📊 **Coverage:** The new test validates that when `RESET` is invoked on a modified state, it correctly clears accumulated entropy, resets coherence, returns the phase to `IDLE`, and assigns the specific `"Sistema reiniciado manualmente."` history message, while also verifying that `lastUpdate` is correctly updated.
✨ **Result:** Test coverage for `QuantumEngine` is improved, ensuring reliability when resetting the system.

---
*PR created automatically by Jules for task [16052339897291693556](https://jules.google.com/task/16052339897291693556) started by @mexicodxnmexico-create*