### PR TITLE
🧪 [Testing Improvement] Add validation for reflectionCount in PersonalInsight

### DIFF
--- a/components/PersonalInsight.tsx
+++ b/components/PersonalInsight.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { memo } from "react";
+import { getInsightMessage } from "../lib/insight";
 
 export const PersonalInsight = memo(function PersonalInsight({ reflectionCount }: { reflectionCount: number }) {
-  let message = "";
-  if (reflectionCount === 0) message = "Aún no has proyectado tu intención en el espejo.";
-  else if (reflectionCount < 3) message = "Tus primeros reflejos muestran una búsqueda de equilibrio.";
-  else if (reflectionCount < 6) message = "La profundidad de tus proyecciones está alterando el tejido del sistema.";
-  else message = "Eres un maestro de la realidad reflejada. El espejo y tú sois uno.";
+  const message = getInsightMessage(reflectionCount);
+
+  if (message === null) {
+    return null;
+  }
 
   return (
     <div style={{ marginTop: "3rem", padding: "1.5rem", borderRadius: "12px", background: "linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)", textAlign: "center" }}>

--- a/lib/insight.test.ts
+++ b/lib/insight.test.ts
@@ -1,0 +1,36 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { getInsightMessage } from './insight.ts';
+
+test('getInsightMessage returns correct message for 0 reflections', () => {
+  assert.strictEqual(getInsightMessage(0), "Aún no has proyectado tu intención en el espejo.");
+});
+
+test('getInsightMessage returns correct message for 1 or 2 reflections', () => {
+  assert.strictEqual(getInsightMessage(1), "Tus primeros reflejos muestran una búsqueda de equilibrio.");
+  assert.strictEqual(getInsightMessage(2), "Tus primeros reflejos muestran una búsqueda de equilibrio.");
+});
+
+test('getInsightMessage returns correct message for 3 to 5 reflections', () => {
+  assert.strictEqual(getInsightMessage(3), "La profundidad de tus proyecciones está alterando el tejido del sistema.");
+  assert.strictEqual(getInsightMessage(4), "La profundidad de tus proyecciones está alterando el tejido del sistema.");
+  assert.strictEqual(getInsightMessage(5), "La profundidad de tus proyecciones está alterando el tejido del sistema.");
+});
+
+test('getInsightMessage returns correct message for 6 or more reflections', () => {
+  assert.strictEqual(getInsightMessage(6), "Eres un maestro de la realidad reflejada. El espejo y tú sois uno.");
+  assert.strictEqual(getInsightMessage(10), "Eres un maestro de la realidad reflejada. El espejo y tú sois uno.");
+});
+
+test('getInsightMessage returns null for invalid inputs', () => {
+  assert.strictEqual(getInsightMessage(-1), null);
+  assert.strictEqual(getInsightMessage(-10), null);
+  assert.strictEqual(getInsightMessage(NaN), null);
+
+  // @ts-expect-error Testing invalid runtime types
+  assert.strictEqual(getInsightMessage("not a number"), null);
+  // @ts-expect-error Testing invalid runtime types
+  assert.strictEqual(getInsightMessage(null), null);
+  // @ts-expect-error Testing invalid runtime types
+  assert.strictEqual(getInsightMessage(undefined), null);
+});

--- a/lib/insight.ts
+++ b/lib/insight.ts
@@ -1,0 +1,11 @@
+export function getInsightMessage(reflectionCount: number): string | null {
+  if (typeof reflectionCount !== 'number' || isNaN(reflectionCount) || reflectionCount < 0) {
+    return null;
+  }
+
+  if (reflectionCount === 0) return "Aún no has proyectado tu intención en el espejo.";
+  if (reflectionCount < 3) return "Tus primeros reflejos muestran una búsqueda de equilibrio.";
+  if (reflectionCount < 6) return "La profundidad de tus proyecciones está alterando el tejido del sistema.";
+
+  return "Eres un maestro de la realidad reflejada. El espejo y tú sois uno.";
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
🎯 **What:** The `PersonalInsight` component previously lacked validation for its `reflectionCount` prop. If invalid data (like negative numbers or `NaN`) was passed, the UI could behave unpredictably. This PR addresses the gap by extracting the message logic to a pure, testable function `getInsightMessage`, which includes strict runtime validation to return `null` on corrupt inputs. The UI component is updated to gracefully return `null` when the data is invalid.

📊 **Coverage:** A new suite of unit tests (`lib/insight.test.ts`) has been created to cover:
*   Valid inputs corresponding to each defined message band (0, 1-2, 3-5, 6+).
*   Edge cases with negative numbers.
*   Invalid data types (simulated in JS like string, null, undefined) and `NaN`.

✨ **Result:** Test coverage for this logic is significantly improved, ensuring both type safety during compile time and robust validation at runtime. The UI is now resilient against broken inputs, gracefully handling errors by rendering nothing.

---
*PR created automatically by Jules for task [8591938751482796282](https://jules.google.com/task/8591938751482796282) started by @mexicodxnmexico-create*