### PR TITLE
🧪 [testing improvement] Add test for QuantumEngine ENTANGLED state transition

### DIFF
--- a/tests/quantum-engine.test.ts
+++ b/tests/quantum-engine.test.ts
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { QuantumEngine, INITIAL_STATE } from '../lib/quantum-engine';
+
+test('QuantumEngine.transition', async (t) => {
+    await t.test('transitions to ENTANGLED when entropy > 50 and phase is not COLLAPSED', () => {
+        const initialState = {
+            ...INITIAL_STATE,
+            coherence: 50,
+            entropy: 49,
+            phase: 'IDLE' as any,
+        };
+
+        const newState = QuantumEngine.transition(initialState, 'OBSERVE');
+
+        assert.strictEqual(newState.entropy, 51);
+        assert.strictEqual(newState.phase, 'ENTANGLED');
+    });
+
+    await t.test('transitions to COLLAPSED instead of ENTANGLED when coherence <= 0', () => {
+        const initialState = {
+            ...INITIAL_STATE,
+            coherence: 1,
+            entropy: 49,
+            phase: 'IDLE' as any,
+        };
+
+        const newState = QuantumEngine.transition(initialState, 'OBSERVE');
+
+        assert.strictEqual(newState.entropy, 51);
+        assert.strictEqual(newState.coherence, 0);
+        assert.strictEqual(newState.phase, 'COLLAPSED');
+    });
+
+    await t.test('does not transition to ENTANGLED if entropy <= 50', () => {
+        const initialState = {
+            ...INITIAL_STATE,
+            coherence: 50,
+            entropy: 48,
+            phase: 'IDLE' as any,
+        };
+
+        const newState = QuantumEngine.transition(initialState, 'OBSERVE');
+
+        assert.strictEqual(newState.entropy, 50);
+        assert.strictEqual(newState.phase, 'OBSERVING');
+    });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of test coverage for the `ENTANGLED` state transition logic within the `QuantumEngine.transition` method.

📊 **Coverage:** The new test file covers the following scenarios:
1. Transitioning to the `ENTANGLED` phase when the entropy exceeds 50 and the state hasn't collapsed.
2. The priority of the `COLLAPSED` state transition when the coherence drops to 0 or below, overriding the `ENTANGLED` transition even if the entropy exceeds 50.
3. Not transitioning to the `ENTANGLED` phase when the entropy is exactly 50 or below (falling back to the standard action transition).

✨ **Result:** Test coverage for `lib/quantum-engine.ts` has been effectively improved with three targeted tests that successfully evaluate the deterministic state transitions of the Quantum engine core logic.

---
*PR created automatically by Jules for task [18130950516718632475](https://jules.google.com/task/18130950516718632475) started by @mexicodxnmexico-create*