### PR TITLE
🎨 Palette: Improve disabled button UX and accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-24 - Text Contrast Standards
 **Learning:** Text color '#999' on light backgrounds (e.g., '#fafafa') fails WCAG AA contrast ratio (approx 2.9:1).
 **Action:** Use '#555' (approx 7.5:1) or darker for secondary text to ensure readability for all users.
+
+## 2024-03-03 - Disabled Button States in Inline Styled Apps
+**Learning:** In applications relying heavily on inline styles (like this one), standard HTML `disabled` attributes don't automatically confer visual disabled styling. Furthermore, standard disabled pointers don't explicitly explain the restriction.
+**Action:** When working with inline styles, ensure `opacity: 0.5` and `cursor: not-allowed` are explicitly added to disabled buttons. Pair this with a `title` attribute explaining exactly *why* the action is restricted for better accessibility and user context.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,6 +21,7 @@ const CARD_STYLE: CSSProperties = { padding: "2rem", borderRadius: "16px", borde
 const CARD_LABEL_STYLE: CSSProperties = { fontSize: "0.8rem", textTransform: "uppercase", color: "#555", fontWeight: "bold" };
 const OBSERVE_BTN_STYLE: CSSProperties = { width: "100%", padding: "0.75rem", borderRadius: "8px", border: "1px solid #000", background: "none", cursor: "pointer", fontWeight: "bold" };
 const REFLECT_BTN_STYLE: CSSProperties = { width: "100%", padding: "0.75rem", borderRadius: "12px", backgroundColor: "#000", color: "#fff", border: "none", cursor: "pointer", fontWeight: "bold" };
+const DISABLED_BTN_STYLE: CSSProperties = { opacity: 0.5, cursor: "not-allowed" };
 const COLLAPSED_STYLE: CSSProperties = { padding: "2rem", backgroundColor: "#fff0f0", borderRadius: "12px", border: "1px solid #ff0000", textAlign: "center", marginBottom: "4rem", marginTop: "4rem" };
 const COLLAPSED_H3_STYLE: CSSProperties = { color: "#ff0000", margin: 0 };
 const COLLAPSED_P_STYLE: CSSProperties = { margin: "1rem 0" };
@@ -79,6 +80,11 @@ export default function Home() {
     }
   }, []);
 
+    // Memoized styles for disabled states
+  const isCollapsed = state.phase === "COLLAPSED";
+  const observeStyle = useMemo(() => isCollapsed ? { ...OBSERVE_BTN_STYLE, ...DISABLED_BTN_STYLE } : OBSERVE_BTN_STYLE, [isCollapsed]);
+  const reflectStyle = useMemo(() => isCollapsed ? { ...REFLECT_BTN_STYLE, ...DISABLED_BTN_STYLE } : REFLECT_BTN_STYLE, [isCollapsed]);
+
   const completeOnboarding = useCallback(() => {
     setShowOnboarding(false);
     localStorage.setItem("quantum_onboarded", "true");
@@ -109,7 +115,8 @@ export default function Home() {
             <button
               onClick={() => dispatch("OBSERVE")}
               disabled={state.phase === "COLLAPSED"}
-              style={OBSERVE_BTN_STYLE}
+              style={observeStyle}
+              title={isCollapsed ? "El sistema ha colapsado. Restaura el espejo para continuar." : undefined}
             >
               Observar
             </button>
@@ -123,7 +130,8 @@ export default function Home() {
             <button
               onClick={() => dispatch("REFLECT")}
               disabled={state.phase === "COLLAPSED"}
-              style={REFLECT_BTN_STYLE}
+              style={reflectStyle}
+              title={isCollapsed ? "El sistema ha colapsado. Restaura el espejo para continuar." : undefined}
             >
               Reflejar
             </button>


### PR DESCRIPTION
💡 **What**: Added explicit visual disabled states (`opacity: 0.5`, `cursor: not-allowed`) to the "Observar" and "Reflejar" buttons when the system enters the `COLLAPSED` state. Additionally, added a `title` tooltip ("El sistema ha colapsado. Restaura el espejo para continuar.") to these buttons when disabled.

🎯 **Why**: In applications relying heavily on inline styles, standard HTML `disabled` attributes don't always confer sufficient visual disabled styling. Furthermore, standard disabled pointers don't explicitly explain the restriction to the user. This change provides clear visual feedback and explicit context on *why* the buttons are disabled and how to fix it, improving overall usability.

📸 **Before/After**:
- Before: Disabled buttons appeared almost identical to enabled buttons, with normal cursors and no explanation.
- After: Disabled buttons appear faded (50% opacity), show a `not-allowed` cursor, and display a helpful tooltip on hover/focus explaining the collapsed state.

♿ **Accessibility**:
- Improves visual feedback for disabled elements, helping users with cognitive or visual impairments quickly understand the state of the interactive elements.
- The `title` attribute provides explicit context, reducing confusion about why actions cannot be taken.

(Also added a critical learning entry to `.jules/palette.md` regarding disabled states in inline-styled applications).

---
*PR created automatically by Jules for task [17338386025165185026](https://jules.google.com/task/17338386025165185026) started by @mexicodxnmexico-create*