### PR TITLE
⚡ Bolt: Eliminate `useMemo` overhead in `HistoryItem` using static module-level constants

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -19,3 +19,7 @@
 ## 2025-06-21 - Render Loop O(n) Date Parsing
 **Learning:** Found that invoking `new Date().toLocaleDateString()` inside a `map` function during the render cycle of a list (e.g., in `ProgressDashboard.tsx`) causes significant O(n) overhead due to repetitive string and object instantiations.
 **Action:** Extract expensive formatting operations into a `useMemo` hook that pre-calculates the formatted values. Then map over the memoized array, reducing the cost to O(1) for re-renders where the source array hasn't changed.
+
+## 2025-07-15 - Eliminating useMemo in Hot Lists
+**Learning:** Found that using `useMemo` for inline styles inside a frequently rendered list item component (e.g., `HistoryItem` in `app/page.tsx` rendering up to 50 items) introduces unnecessary hook overhead (invocation, dependency tracking, closure allocation). This is especially true when the possible style objects are finite and stable based on boolean props (like `isLatest`).
+**Action:** Extract the static style objects to module-level constants (`LATEST_HISTORY_ITEM_STYLE` and `NORMAL_HISTORY_ITEM_STYLE`) and use a simple ternary operator to assign them. This completely eliminates hook overhead within the list item component, improving render performance in hot paths.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -38,15 +38,13 @@ const LOG_CONTAINER_STYLE: CSSProperties = {
 };
 const LIST_STYLE: CSSProperties = { display: "flex", flexDirection: "column-reverse", listStyle: "none", padding: 0, margin: 0 };
 const FOOTER_STYLE: CSSProperties = { padding: "4rem 0", textAlign: "center", borderTop: "1px solid #eaeaea", color: "#555", fontSize: "0.8rem" };
-const HISTORY_ITEM_STYLE_BASE: CSSProperties = { marginBottom: "0.5rem", borderBottom: "1px solid #eee", paddingBottom: "0.5rem" };
+const LATEST_HISTORY_ITEM_STYLE: CSSProperties = { marginBottom: "0.5rem", borderBottom: "1px solid #eee", paddingBottom: "0.5rem", color: "#000" };
+const NORMAL_HISTORY_ITEM_STYLE: CSSProperties = { marginBottom: "0.5rem", borderBottom: "1px solid #eee", paddingBottom: "0.5rem", color: "#555" };
 
-// ⚡ BOLT OPTIMIZATION: Memoized HistoryItem component
-// Prevents re-rendering of existing history items when a new one is added.
+// ⚡ BOLT OPTIMIZATION: Memoized HistoryItem component with pre-calculated styles
+// Prevents useMemo overhead within the component for up to 50 rendered items.
 const HistoryItem = memo(function HistoryItem({ entry, isLatest }: { entry: string; isLatest: boolean }) {
-  const style = useMemo<CSSProperties>(() => ({
-    ...HISTORY_ITEM_STYLE_BASE,
-    color: isLatest ? "#000" : "#555"
-  }), [isLatest]);
+  const style = isLatest ? LATEST_HISTORY_ITEM_STYLE : NORMAL_HISTORY_ITEM_STYLE;
 
   return (
     <li style={style}>


### PR DESCRIPTION
⚡ Bolt: Eliminate `useMemo` overhead in `HistoryItem` by using static module-level constants for styles.

💡 What: Replaced the `useMemo` hook inside the `HistoryItem` component in `app/page.tsx` with static module-level constants `LATEST_HISTORY_ITEM_STYLE` and `NORMAL_HISTORY_ITEM_STYLE`.
🎯 Why: `useMemo` has inherent overhead (invocation, dependency tracking, closure allocation). For a hot path component like `HistoryItem` that renders up to 50 items simultaneously, calculating styles inline with a hook is unnecessary when the possible style objects are finite and stable based on the `isLatest` boolean prop.
📊 Impact: Completely eliminates hook overhead within the list item component, reducing garbage collection pressure and improving list render performance in a hot path.
🔬 Measurement: Verified that the UI correctly applies bold/black styles to the latest history item and grey styles to previous ones. Can be verified by running the application, observing the system, and monitoring React Developer Tools profiler during rapid "Observe" clicks.

---
*PR created automatically by Jules for task [17419811482326443554](https://jules.google.com/task/17419811482326443554) started by @mexicodxnmexico-create*