### PR TITLE
🎨 Palette: Improve disabled button states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-24 - Text Contrast Standards
 **Learning:** Text color '#999' on light backgrounds (e.g., '#fafafa') fails WCAG AA contrast ratio (approx 2.9:1).
 **Action:** Use '#555' (approx 7.5:1) or darker for secondary text to ensure readability for all users.
+
+## 2024-05-25 - Disabled Button States
+**Learning:** To clearly communicate disabled states for accessibility and UX, buttons should visually reflect their state using CSS styles like `opacity: 0.5` and `cursor: not-allowed` instead of retaining normal pointers, and should provide context using a `title` attribute or tooltip explaining why the action is restricted.
+**Action:** Always verify disabled buttons have both visual distinction and contextual explanation for screen readers and pointer-users alike.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,7 +20,9 @@ const GRID_STYLE: CSSProperties = { display: "grid", gridTemplateColumns: "1fr 1
 const CARD_STYLE: CSSProperties = { padding: "2rem", borderRadius: "16px", border: "1px solid #eaeaea", textAlign: "center" };
 const CARD_LABEL_STYLE: CSSProperties = { fontSize: "0.8rem", textTransform: "uppercase", color: "#555", fontWeight: "bold" };
 const OBSERVE_BTN_STYLE: CSSProperties = { width: "100%", padding: "0.75rem", borderRadius: "8px", border: "1px solid #000", background: "none", cursor: "pointer", fontWeight: "bold" };
+const OBSERVE_BTN_STYLE_DISABLED: CSSProperties = { width: "100%", padding: "0.75rem", borderRadius: "8px", border: "1px solid #000", background: "none", cursor: "not-allowed", fontWeight: "bold", opacity: 0.5 };
 const REFLECT_BTN_STYLE: CSSProperties = { width: "100%", padding: "0.75rem", borderRadius: "12px", backgroundColor: "#000", color: "#fff", border: "none", cursor: "pointer", fontWeight: "bold" };
+const REFLECT_BTN_STYLE_DISABLED: CSSProperties = { width: "100%", padding: "0.75rem", borderRadius: "12px", backgroundColor: "#000", color: "#fff", border: "none", cursor: "not-allowed", fontWeight: "bold", opacity: 0.5 };
 const COLLAPSED_STYLE: CSSProperties = { padding: "2rem", backgroundColor: "#fff0f0", borderRadius: "12px", border: "1px solid #ff0000", textAlign: "center", marginBottom: "4rem", marginTop: "4rem" };
 const COLLAPSED_H3_STYLE: CSSProperties = { color: "#ff0000", margin: 0 };
 const COLLAPSED_P_STYLE: CSSProperties = { margin: "1rem 0" };
@@ -109,7 +111,8 @@ export default function Home() {
             <button
               onClick={() => dispatch("OBSERVE")}
               disabled={state.phase === "COLLAPSED"}
-              style={OBSERVE_BTN_STYLE}
+              style={state.phase === "COLLAPSED" ? OBSERVE_BTN_STYLE_DISABLED : OBSERVE_BTN_STYLE}
+              title={state.phase === "COLLAPSED" ? "El sistema está colapsado" : undefined}
             >
               Observar
             </button>
@@ -123,7 +126,8 @@ export default function Home() {
             <button
               onClick={() => dispatch("REFLECT")}
               disabled={state.phase === "COLLAPSED"}
-              style={REFLECT_BTN_STYLE}
+              style={state.phase === "COLLAPSED" ? REFLECT_BTN_STYLE_DISABLED : REFLECT_BTN_STYLE}
+              title={state.phase === "COLLAPSED" ? "El sistema está colapsado" : undefined}
             >
               Reflejar
             </button>


### PR DESCRIPTION
💡 **What:** Added static disabled CSS properties (`opacity: 0.5` and `cursor: "not-allowed"`) to the "Observar" and "Reflejar" buttons when the system enters the COLLAPSED state. Additionally, added a `title` attribute explaining that the buttons are disabled because "El sistema está colapsado".
🎯 **Why:** Previously, the buttons only had the `disabled` HTML attribute, meaning they appeared visually identical to active buttons and provided no explanation as to why they couldn't be clicked. This was confusing and inaccessible.
📸 **Before/After:** The buttons now visually dim when disabled and show a native tooltip when hovered, explaining the restricted state.
♿ **Accessibility:** Visually impaired users or users who rely on screen readers now get contextual text (`title`) explaining the disabled state instead of just hearing "disabled". Sighted users clearly see the `not-allowed` cursor and faded opacity, removing the guess work.

---
*PR created automatically by Jules for task [16365424334561189353](https://jules.google.com/task/16365424334561189353) started by @mexicodxnmexico-create*