### PR TITLE
🎨 Palette: Add explicit disabled states to action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-24 - Text Contrast Standards
 **Learning:** Text color '#999' on light backgrounds (e.g., '#fafafa') fails WCAG AA contrast ratio (approx 2.9:1).
 **Action:** Use '#555' (approx 7.5:1) or darker for secondary text to ensure readability for all users.
+
+## 2024-05-25 - Disabled State Visibility
+**Learning:** Buttons with only a 'disabled' boolean prop might still look clickable and leave users confused if there's no visual feedback or explanation.
+**Action:** Always pair 'disabled' states with visual cues (like 'opacity: 0.5' and 'cursor: not-allowed') and provide context using a 'title' attribute or tooltip explaining why the action is restricted.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,6 +21,8 @@ const CARD_STYLE: CSSProperties = { padding: "2rem", borderRadius: "16px", borde
 const CARD_LABEL_STYLE: CSSProperties = { fontSize: "0.8rem", textTransform: "uppercase", color: "#555", fontWeight: "bold" };
 const OBSERVE_BTN_STYLE: CSSProperties = { width: "100%", padding: "0.75rem", borderRadius: "8px", border: "1px solid #000", background: "none", cursor: "pointer", fontWeight: "bold" };
 const REFLECT_BTN_STYLE: CSSProperties = { width: "100%", padding: "0.75rem", borderRadius: "12px", backgroundColor: "#000", color: "#fff", border: "none", cursor: "pointer", fontWeight: "bold" };
+const OBSERVE_BTN_DISABLED_STYLE: CSSProperties = { ...OBSERVE_BTN_STYLE, opacity: 0.5, cursor: "not-allowed" };
+const REFLECT_BTN_DISABLED_STYLE: CSSProperties = { ...REFLECT_BTN_STYLE, opacity: 0.5, cursor: "not-allowed" };
 const COLLAPSED_STYLE: CSSProperties = { padding: "2rem", backgroundColor: "#fff0f0", borderRadius: "12px", border: "1px solid #ff0000", textAlign: "center", marginBottom: "4rem", marginTop: "4rem" };
 const COLLAPSED_H3_STYLE: CSSProperties = { color: "#ff0000", margin: 0 };
 const COLLAPSED_P_STYLE: CSSProperties = { margin: "1rem 0" };
@@ -109,7 +111,8 @@ export default function Home() {
             <button
               onClick={() => dispatch("OBSERVE")}
               disabled={state.phase === "COLLAPSED"}
-              style={OBSERVE_BTN_STYLE}
+              style={state.phase === "COLLAPSED" ? OBSERVE_BTN_DISABLED_STYLE : OBSERVE_BTN_STYLE}
+              title={state.phase === "COLLAPSED" ? "El sistema ha colapsado. Restaura el espejo para continuar." : undefined}
             >
               Observar
             </button>
@@ -123,7 +126,8 @@ export default function Home() {
             <button
               onClick={() => dispatch("REFLECT")}
               disabled={state.phase === "COLLAPSED"}
-              style={REFLECT_BTN_STYLE}
+              style={state.phase === "COLLAPSED" ? REFLECT_BTN_DISABLED_STYLE : REFLECT_BTN_STYLE}
+              title={state.phase === "COLLAPSED" ? "El sistema ha colapsado. Restaura el espejo para continuar." : undefined}
             >
               Reflejar
             </button>


### PR DESCRIPTION
### 💡 What
Added explicit disabled states and contextual tooltips to the "Observar" and "Reflejar" buttons in `app/page.tsx` when the system reaches the `COLLAPSED` phase. 

### 🎯 Why
Previously, when the system collapsed, the action buttons became unclickable but retained their default styling and pointer cursors. This created a confusing experience where buttons appeared active but were unresponsive. By adding `opacity: 0.5`, `cursor: not-allowed`, and a helpful `title` attribute, users are now immediately informed *why* the action is restricted and what they need to do to proceed.

### 📸 Before/After
**Before:** The "Observar" and "Reflejar" buttons looked identical whether active or disabled.
**After:** When disabled, the buttons are visibly faded out, display a "not-allowed" cursor, and show a tooltip: "El sistema ha colapsado. Restaura el espejo para continuar."

### ♿ Accessibility
- Improved state communication: Users relying on tooltips or hover states now receive clear textual context for why a button is disabled, rather than just encountering a silent failure when clicking.
- Reduced cognitive load by visually distinguishing inactive elements.

---
*PR created automatically by Jules for task [4618748195278871145](https://jules.google.com/task/4618748195278871145) started by @mexicodxnmexico-create*