### PR TITLE
🎨 Palette: Add visual cues and tooltips for disabled actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - Accessibility in Custom Modals
 **Learning:** The application uses custom `div` overlays for modals (like `Onboarding`) without native `dialog` elements or ARIA attributes. This completely hides context from screen readers and traps keyboard focus in the underlying page.
 **Action:** When encountering custom overlays, immediately check for `role="dialog"`, `aria-modal="true"`, and focus management. Simple `useEffect` focus on the primary action is a high-value, low-effort fix for these patterns.
+
+## 2025-02-18 - Disabled Button Context
+**Learning:** In highly interactive or 'game-like' components (e.g., QuantumEngine controls), users may become confused when core actions are abruptly disabled without visual cues or explanation.
+**Action:** Whenever a button is dynamically disabled, always implement a distinct visual style (e.g., `opacity: 0.5`, `cursor: not-allowed`) and a `title` attribute or tooltip explaining *why* the action is restricted.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,6 +25,8 @@ const COHERENCE_CRITICAL_STYLE: CSSProperties = { ...COHERENCE_VALUE_STYLE, colo
 const ENTROPY_VALUE_STYLE: CSSProperties = { fontSize: "3rem", fontWeight: "bold", margin: "0.5rem 0" };
 const OBSERVE_BTN_STYLE: CSSProperties = { width: "100%", padding: "0.75rem", borderRadius: "8px", border: "1px solid #000", background: "none", cursor: "pointer", fontWeight: "bold" };
 const REFLECT_BTN_STYLE: CSSProperties = { width: "100%", padding: "0.75rem", borderRadius: "12px", backgroundColor: "#000", color: "#fff", border: "none", cursor: "pointer", fontWeight: "bold" };
+const OBSERVE_BTN_STYLE_DISABLED: CSSProperties = { ...OBSERVE_BTN_STYLE, opacity: 0.5, cursor: "not-allowed" };
+const REFLECT_BTN_STYLE_DISABLED: CSSProperties = { ...REFLECT_BTN_STYLE, opacity: 0.5, cursor: "not-allowed" };
 const COLLAPSED_STYLE: CSSProperties = { padding: "2rem", backgroundColor: "#fff0f0", borderRadius: "12px", border: "1px solid #ff0000", textAlign: "center", marginBottom: "4rem", marginTop: "4rem" };
 const COLLAPSED_H3_STYLE: CSSProperties = { color: "#ff0000", margin: 0 };
 const COLLAPSED_P_STYLE: CSSProperties = { margin: "1rem 0" };
@@ -114,7 +116,8 @@ export default function Home() {
             <button
               onClick={() => dispatch("OBSERVE")}
               disabled={state.phase === "COLLAPSED"}
-              style={OBSERVE_BTN_STYLE}
+              style={state.phase === "COLLAPSED" ? OBSERVE_BTN_STYLE_DISABLED : OBSERVE_BTN_STYLE}
+              title={state.phase === "COLLAPSED" ? "El sistema ha colapsado. Reinicie el espejo." : undefined}
             >
               Observar
             </button>
@@ -128,7 +131,8 @@ export default function Home() {
             <button
               onClick={() => dispatch("REFLECT")}
               disabled={state.phase === "COLLAPSED"}
-              style={REFLECT_BTN_STYLE}
+              style={state.phase === "COLLAPSED" ? REFLECT_BTN_STYLE_DISABLED : REFLECT_BTN_STYLE}
+              title={state.phase === "COLLAPSED" ? "El sistema ha colapsado. Reinicie el espejo." : undefined}
             >
               Reflejar
             </button>


### PR DESCRIPTION
💡 What: Added explicit disabled styles (`opacity: 0.5`, `cursor: not-allowed`) and a `title` attribute explaining the state for the "Observar" and "Reflejar" action buttons when the system enters the "COLLAPSED" phase.
🎯 Why: When the system abruptly collapses, the main action buttons become inactive. Providing clear visual cues and a tooltip contextualizes this restriction for users rather than silently disabling functionality.
📸 Before/After: Verified visually via verification Playwright script.
♿ Accessibility: Ensures that users attempting to interact with the disabled controls receive immediate feedback and context as to why the interaction is prohibited.

---
*PR created automatically by Jules for task [17833059623773141027](https://jules.google.com/task/17833059623773141027) started by @mexicodxnmexico-create*