### PR TITLE
🎨 Palette: Add semantic labels to meditation form for improved accessibility

### DIFF
--- a/components/meditacion/MeditacionAudioVisual3D.tsx
+++ b/components/meditacion/MeditacionAudioVisual3D.tsx
@@ -146,10 +146,10 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="frecuencia" style={{ display: "block", fontSize: "1rem", marginBottom: "1rem", color: "#333", fontWeight: "bold" }}>
             Frecuencia Solfeggio
-          </h3>
-          <select
+          </label>
+          <select id="frecuencia"
             value={frecuenciaSeleccionada}
             onChange={(e) => setFrecuenciaSeleccionada(Number(e.target.value))}
             disabled={activo}
@@ -176,10 +176,10 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="geometria" style={{ display: "block", fontSize: "1rem", marginBottom: "1rem", color: "#333", fontWeight: "bold" }}>
             Geometría Sagrada
-          </h3>
-          <select
+          </label>
+          <select id="geometria"
             value={geometriaSeleccionada}
             onChange={(e) => setGeometriaSeleccionada(e.target.value as any)}
             disabled={activo}
@@ -206,10 +206,10 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="duracion" style={{ display: "block", fontSize: "1rem", marginBottom: "1rem", color: "#333", fontWeight: "bold" }}>
             Duración (minutos)
-          </h3>
-          <input
+          </label>
+          <input id="duracion"
             type="number"
             min="1"
             max="60"


### PR DESCRIPTION
### 💡 What
Replaced generic `<h3>` heading tags with proper semantic `<label>` tags for the form controls in the 3D Meditation configuration panel.

### 🎯 Why
To improve accessibility and usability. Screen readers rely on semantic `<label>` elements linked to inputs (via `htmlFor` and `id`) to correctly announce the purpose of form fields. Using `<h3>` tags as visual labels fails to provide this necessary programmatic association.

### 📸 Before/After
Before:
Form fields (Frecuencia, Geometría, Duración) were visually labeled using `<h3>` tags, providing no context to screen readers focusing on the inputs.

After:
Form fields are wrapped in semantic `<label>` elements explicitly linked to their respective `<select>` and `<input>` elements. The visual appearance remains identical, but the accessibility tree is significantly improved.

### ♿ Accessibility
- Replaced `<h3>` with `<label>` for "Frecuencia Solfeggio", "Geometría Sagrada", and "Duración (minutos)".
- Added `htmlFor` attributes to labels and corresponding `id` attributes to the associated form controls, ensuring proper focus and screen reader announcements.

---
*PR created automatically by Jules for task [7674150914268000650](https://jules.google.com/task/7674150914268000650) started by @mexicodxnmexico-create*