### PR TITLE
🧪 Add test for QuantumMirror component deviceorientation logic

### DIFF
--- a/tests/quantum-mirror.test.tsx
+++ b/tests/quantum-mirror.test.tsx
@@ -91,6 +91,45 @@ test('QuantumMirror deviceorientation logic', async (t) => {
   });
 
 
+
+  await t.test('handles floating point beta values requiring rounding', () => {
+    let root: TestRenderer.ReactTestRenderer | undefined;
+
+    TestRenderer.act(() => {
+      root = TestRenderer.create(<QuantumMirror />);
+    });
+
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 10, beta: 45.6, gamma: 10 });
+        });
+      }
+    });
+
+    const freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+
+    // 432 + Math.round(45.6 / 10) = 432 + 5 = 437
+    assert.strictEqual(freqDiv.children[0], '437');
+
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 10, beta: 44.4, gamma: 10 });
+        });
+      }
+    });
+
+    // 432 + Math.round(44.4 / 10) = 432 + 4 = 436
+    assert.strictEqual(freqDiv.children[0], '436');
+
+    TestRenderer.act(() => {
+      root!.unmount();
+    });
+  });
+
   await t.test('handles negative and zero beta values correctly', () => {
     let root: TestRenderer.ReactTestRenderer | undefined;
 


### PR DESCRIPTION
🎯 **What:** The `QuantumMirror` component relies on the `deviceorientation` logic to correctly compute a base frequency `Math.round(e.beta / 10)`. Previously, only integer zero/negative behaviors were explicitly confirmed, leaving floats susceptible to rounding regressions.

📊 **Coverage:** Added explicit coverage ensuring floating-point `beta` values are properly rounded (`45.6` evaluates to `437` while `44.4` evaluates to `436`).

✨ **Result:** Test robustness has increased. The components edge cases for floating point evaluations of sensor variables is now properly verified, increasing code reliability for real-world devices.

---
*PR created automatically by Jules for task [10080829784134203319](https://jules.google.com/task/10080829784134203319) started by @mexicodxnmexico-create*