### PR TITLE
⚡ Bolt: optimize 3D scene rendering and decouple particle updates

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,11 @@
 ## 2025-06-24 - Efficient Fixed-Size Array Updates
 **Learning:** Using `[...arr, item].slice(-N)` for maintaining a fixed-size buffer causes two array allocations (one for the spread and one for the final slice). While `shift()` is O(n), using `slice()` followed by `push()` and `shift()` is significantly faster because it minimizes heap pressure by avoiding the intermediate array allocation.
 **Action:** Prefer `slice()` + `push()` + `shift()` for more efficient memory management in state transitions.
+
+## 2025-06-25 - Internalizing Animation Logic to Prevent Parent Re-renders
+**Learning:** Frequent parent state updates (e.g., `intensidad` every 2 seconds via `setInterval`) trigger expensive re-renders of the entire 3D scene (`Canvas` and all children) in React Three Fiber.
+**Action:** Internalize high-frequency or repetitive animation logic within child components using `useRef` and `useFrame`. This allows for direct property mutation (e.g., `material.emissiveIntensity`) without reconciliation overhead.
+
+## 2025-06-26 - Decoupling O(N) Initialization from Dynamic Updates
+**Learning:** Re-calculating all particle attributes (e.g., positions, sizes) when only a subset (e.g., colors) depends on a changing prop (e.g., `frecuencia`) causes redundant O(N) overhead and visual artifacts like "jumping" particles.
+**Action:** Use separate `useMemo` hooks to decouple static or semi-static attributes from high-frequency or prop-dependent ones. This ensures that only the necessary calculations occur when specific dependencies change.

--- a/components/3d/EscenaMeditacion3D.tsx
+++ b/components/3d/EscenaMeditacion3D.tsx
@@ -2,7 +2,7 @@
 
 import { Canvas } from "@react-three/fiber";
 import { OrbitControls, Stars, Environment } from "@react-three/drei";
-import { Suspense, useState, useEffect, memo } from "react";
+import { Suspense, memo } from "react";
 import { GeometriaSagrada3D } from "./GeometriaSagrada3D";
 import { ParticulasCuanticas } from "./ParticulasCuanticas";
 
@@ -12,23 +12,10 @@ interface EscenaMeditacion3DProps {
   tipoGeometria: "flor-vida" | "merkaba" | "metatron" | "torus";
 }
 
-// ⚡ BOLT: Wrap in React.memo to prevent massive 3D canvas re-renders caused by parent 1-second timers
+// ⚡ BOLT: Wrap in React.memo to prevent massive 3D canvas re-renders caused by parent 1-second timers.
+// ⚡ BOLT: Removed intensidad state and its effect to eliminate unnecessary re-renders every 2 seconds.
+// The intensity random walk is now handled internally by GeometriaSagrada3D using useFrame.
 export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia, activo, tipoGeometria }: EscenaMeditacion3DProps) {
-  const [intensidad, setIntensidad] = useState(50);
-
-  useEffect(() => {
-    if (!activo) return;
-
-    const intervalo = setInterval(() => {
-      setIntensidad(prev => {
-        const nuevo = prev + (Math.random() - 0.5) * 10;
-        return Math.max(30, Math.min(70, nuevo));
-      });
-    }, 2000);
-
-    return () => clearInterval(intervalo);
-  }, [activo]);
-
   return (
     <div style={{ width: "100%", height: "600px", borderRadius: "20px", overflow: "hidden" }}>
       <Canvas
@@ -55,7 +42,7 @@ export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia,
 
           <GeometriaSagrada3D
             frecuencia={frecuencia}
-            intensidad={intensidad}
+            activo={activo}
             tipo={tipoGeometria}
           />
 

--- a/components/3d/GeometriaSagrada3D.tsx
+++ b/components/3d/GeometriaSagrada3D.tsx
@@ -6,13 +6,16 @@ import * as THREE from "three";
 
 interface GeometriaSagrada3DProps {
   frecuencia: number;
-  intensidad: number;
+  activo: boolean; // ⚡ BOLT: Recibe estado activo en lugar de intensidad
   tipo: "flor-vida" | "merkaba" | "metatron" | "torus";
 }
 
-export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSagrada3DProps) {
+export function GeometriaSagrada3D({ frecuencia, activo, tipo }: GeometriaSagrada3DProps) {
   const grupoRef = useRef<THREE.Group>(null);
   const tiempo = useRef(0);
+  // ⚡ BOLT: Internalizar el random walk de intensidad para evitar re-renders del padre
+  const intensidadRef = useRef(50);
+  const ultimoUpdateIntensidad = useRef(0);
 
   // ⚡ OPTIMIZACIÓN: Calcular color basado en frecuencia solo cuando cambia
   const colorFrecuencia = useMemo(() => {
@@ -64,8 +67,9 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
   useEffect(() => {
     material.color.set(colorFrecuencia);
     material.emissive.set(colorFrecuencia);
-    material.emissiveIntensity = intensidad / 100;
-  }, [material, colorFrecuencia, intensidad]);
+    // Inicializar emissiveIntensity
+    material.emissiveIntensity = intensidadRef.current / 100;
+  }, [material, colorFrecuencia]); // ⚡ BOLT: Removida dependencia de intensidad
 
   useEffect(() => {
     return () => material.dispose();
@@ -77,13 +81,20 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
 
     tiempo.current += delta;
 
+    // ⚡ BOLT: Random walk de intensidad cada 2 segundos sin disparar re-renders de React
+    if (activo && tiempo.current - ultimoUpdateIntensidad.current > 2) {
+      intensidadRef.current = Math.max(30, Math.min(70, intensidadRef.current + (Math.random() - 0.5) * 10));
+      material.emissiveIntensity = intensidadRef.current / 100;
+      ultimoUpdateIntensidad.current = tiempo.current;
+    }
+
     // Rotación suave basada en la frecuencia
     const velocidad = frecuencia / 10000;
     grupoRef.current.rotation.y += velocidad;
     grupoRef.current.rotation.x = Math.sin(tiempo.current * 0.3) * 0.2;
 
-    // Pulsación basada en intensidad
-    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidad / 200);
+    // Pulsación basada en intensidad (ahora usando intensidadRef)
+    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidadRef.current / 200);
     grupoRef.current.scale.setScalar(escala);
   });
 
@@ -101,21 +112,17 @@ interface GeoData {
   posicion: THREE.Vector3;
 }
 
-// ⚡ OPTIMIZACIÓN: Funciones de generación de geometría memoizadas
-// ⚡ BOLT: Reusing identical geometry instances to reduce memory pressure
 function crearFlorDeLaVida(): GeoData[] {
   const geometrias: GeoData[] = [];
   const radio = 1;
   const numCirculos = 6;
   const torusGeo = new THREE.TorusGeometry(radio, 0.05, 16, 100);
 
-  // Círculo central
   geometrias.push({
     geometria: torusGeo,
     posicion: new THREE.Vector3(0, 0, 0)
   });
 
-  // Círculos exteriores
   for (let i = 0; i < numCirculos; i++) {
     const angulo = (Math.PI * 2 * i) / numCirculos;
     const x = Math.cos(angulo) * radio;
@@ -127,7 +134,6 @@ function crearFlorDeLaVida(): GeoData[] {
     });
   }
 
-  // Segunda capa
   for (let i = 0; i < numCirculos; i++) {
     const angulo = (Math.PI * 2 * i) / numCirculos + Math.PI / numCirculos;
     const x = Math.cos(angulo) * radio * 1.732;
@@ -147,13 +153,11 @@ function crearMerkaba(): GeoData[] {
   const tamaño = 1.5;
   const tetraGeo = new THREE.TetrahedronGeometry(tamaño);
 
-  // Tetraedro superior
   geometrias.push({
     geometria: tetraGeo,
     posicion: new THREE.Vector3(0, 0, 0)
   });
 
-  // Tetraedro inferior (invertido)
   geometrias.push({
     geometria: tetraGeo,
     posicion: new THREE.Vector3(0, 0, 0)
@@ -171,7 +175,6 @@ function crearCuboMetatron(): GeoData[] {
 
   const sphereGeo = new THREE.SphereGeometry(0.15, 16, 16);
 
-  // Esferas en cada vértice
   vertices.forEach(([x, y, z]) => {
     geometrias.push({
       geometria: sphereGeo,
@@ -179,14 +182,12 @@ function crearCuboMetatron(): GeoData[] {
     });
   });
 
-  // Conexiones principales
   const conexiones = [
     [0, 1], [1, 2], [2, 3], [3, 0],
     [4, 5], [5, 6], [6, 7], [7, 4],
     [0, 4], [1, 5], [2, 6], [3, 7]
   ];
 
-  // Reuse a single cylinder geometry for all edges of the cube (length 2.0)
   const cylinderGeo = new THREE.CylinderGeometry(0.03, 0.03, 2, 8);
 
   conexiones.forEach(([i, j]) => {
@@ -207,13 +208,11 @@ function crearTorus(): GeoData[] {
   const geometrias: GeoData[] = [];
   const torusGeo = new THREE.TorusGeometry(1.5, 0.3, 16, 100);
 
-  // Torus principal
   geometrias.push({
     geometria: torusGeo,
     posicion: new THREE.Vector3(0, 0, 0)
   });
 
-  // Torus secundario perpendicular
   geometrias.push({
     geometria: torusGeo,
     posicion: new THREE.Vector3(0, 0, 0)

--- a/components/3d/ParticulasCuanticas.tsx
+++ b/components/3d/ParticulasCuanticas.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useMemo } from "react";
+import { useRef, useMemo, memo } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
@@ -19,20 +19,20 @@ const COLORES_SOLFEGGIO: Record<number, { r: number; g: number; b: number }> = {
   852: { r: 0.51, g: 0.22, b: 0.93 }
 };
 
-export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuanticasProps) {
+// ⚡ BOLT: Wrap in memo to prevent unnecessary re-renders when parent state changes
+export const ParticulasCuanticas = memo(function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuanticasProps) {
   const particulasRef = useRef<THREE.Points>(null);
   const tiempo = useRef(0);
 
-  const [posiciones, colores, tamaños] = useMemo(() => {
+  // ⚡ BOLT OPTIMIZATION: Split useMemo to decouple positions from frequency.
+  // This prevents O(N) re-calculation of 1000 particle positions and avoids
+  // the "jumping" effect when only the color (frequency) changes.
+  const [posiciones, tamaños] = useMemo(() => {
     const pos = new Float32Array(cantidad * 3);
-    const col = new Float32Array(cantidad * 3);
     const tam = new Float32Array(cantidad);
-
-    const colorBase = COLORES_SOLFEGGIO[frecuencia] || { r: 0.02, g: 0.84, b: 0.63 };
 
     for (let i = 0; i < cantidad; i++) {
       const i3 = i * 3;
-
       const radio = Math.random() * 5 + 3;
       const theta = Math.random() * Math.PI * 2;
       const phi = Math.random() * Math.PI;
@@ -41,14 +41,22 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
       pos[i3 + 1] = radio * Math.sin(phi) * Math.sin(theta);
       pos[i3 + 2] = radio * Math.cos(phi);
 
+      tam[i] = Math.random() * 0.05 + 0.02;
+    }
+    return [pos, tam];
+  }, [cantidad]);
+
+  const colores = useMemo(() => {
+    const col = new Float32Array(cantidad * 3);
+    const colorBase = COLORES_SOLFEGGIO[frecuencia] || { r: 0.02, g: 0.84, b: 0.63 };
+
+    for (let i = 0; i < cantidad; i++) {
+      const i3 = i * 3;
       col[i3] = colorBase.r + (Math.random() - 0.5) * 0.2;
       col[i3 + 1] = colorBase.g + (Math.random() - 0.5) * 0.2;
       col[i3 + 2] = colorBase.b + (Math.random() - 0.5) * 0.2;
-
-      tam[i] = Math.random() * 0.05 + 0.02;
     }
-
-    return [pos, col, tam];
+    return col;
   }, [cantidad, frecuencia]);
 
   useFrame((_state, delta) => {
@@ -66,8 +74,6 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
       const y = posicionesArray[i3 + 1];
       const z = posicionesArray[i3 + 2];
 
-      // ⚡ BOLT: Use local variables to avoid repeated TypedArray reads/writes
-      // and squared distance to avoid Math.sqrt in the common case.
       const phase = t + i;
       const nextX = x + Math.sin(phase) * velocidad;
       const nextY = y + Math.cos(phase) * velocidad;
@@ -75,7 +81,6 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
 
       const nextDistSq = nextX * nextX + nextY * nextY + nextZ * nextZ;
 
-      // Range [3, 8] -> Squared Range [9, 64]
       if (nextDistSq > 64 || nextDistSq < 9) {
         const prevDistSq = x * x + y * y + z * z;
         const scale = Math.sqrt(prevDistSq / nextDistSq);
@@ -128,4 +133,4 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
       />
     </points>
   );
-}
+});


### PR DESCRIPTION
💡 What: This PR optimizes the 3D meditation scene by reducing unnecessary React re-renders and decoupling particle attribute updates.

🎯 Why: The previous implementation triggered a full 3D scene re-render (including the `Canvas` and all children) every 2 seconds due to an `intensidad` state update in the parent. Additionally, changing the `frecuencia` caused all 1,000 particle positions to be re-randomized, causing a visual "jumping" effect and redundant O(N) overhead.

📊 Impact: 
- Eliminates 3D scene re-renders every 2 seconds by internalizing the intensity logic.
- Reduces particle update complexity from O(N) for positions and colors to O(N) only for colors when frequency changes.
- Prevents visual artifacts by maintaining stable particle positions.

🔬 Measurement: Verified using Playwright (see screenshot and video) and local performance inspection. All core unit tests passed successfully.


---
*PR created automatically by Jules for task [11648261914162405402](https://jules.google.com/task/11648261914162405402) started by @mexicodxnmexico-create*