### PR TITLE
⚡ Bolt: Bypass 3D canvas React render cycle

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,7 @@
 ## 2025-06-24 - Efficient Fixed-Size Array Updates
 **Learning:** Using `[...arr, item].slice(-N)` for maintaining a fixed-size buffer causes two array allocations (one for the spread and one for the final slice). While `shift()` is O(n), using `slice()` followed by `push()` and `shift()` is significantly faster because it minimizes heap pressure by avoiding the intermediate array allocation.
 **Action:** Prefer `slice()` + `push()` + `shift()` for more efficient memory management in state transitions.
+
+## 2025-06-25 - Escaping 3D Canvas Re-renders
+**Learning:** Found that interval-driven state updates in `EscenaMeditacion3D.tsx` (`intensidad`) caused massive 3D canvas re-renders because `GeometriaSagrada3D` was receiving new props every 2 seconds. While `EscenaMeditacion3D` was wrapped in `React.memo`, its internal state change was still triggering deep subtree updates inside `@react-three/fiber` components.
+**Action:** Removed interval-driven state from the parent (`EscenaMeditacion3D.tsx`) and moved the logic entirely inside `GeometriaSagrada3D.tsx` using `useRef` for tracking state and an `if`-statement inside the `useFrame` hook to control timing. The material property `emissiveIntensity` is directly mutated within the render loop to completely bypass React render cycles for these updates.

--- a/components/3d/EscenaMeditacion3D.tsx
+++ b/components/3d/EscenaMeditacion3D.tsx
@@ -2,7 +2,7 @@
 
 import { Canvas } from "@react-three/fiber";
 import { OrbitControls, Stars, Environment } from "@react-three/drei";
-import { Suspense, useState, useEffect, memo } from "react";
+import { Suspense, memo } from "react";
 import { GeometriaSagrada3D } from "./GeometriaSagrada3D";
 import { ParticulasCuanticas } from "./ParticulasCuanticas";
 
@@ -14,21 +14,6 @@ interface EscenaMeditacion3DProps {
 
 // ⚡ BOLT: Wrap in React.memo to prevent massive 3D canvas re-renders caused by parent 1-second timers
 export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia, activo, tipoGeometria }: EscenaMeditacion3DProps) {
-  const [intensidad, setIntensidad] = useState(50);
-
-  useEffect(() => {
-    if (!activo) return;
-
-    const intervalo = setInterval(() => {
-      setIntensidad(prev => {
-        const nuevo = prev + (Math.random() - 0.5) * 10;
-        return Math.max(30, Math.min(70, nuevo));
-      });
-    }, 2000);
-
-    return () => clearInterval(intervalo);
-  }, [activo]);
-
   return (
     <div style={{ width: "100%", height: "600px", borderRadius: "20px", overflow: "hidden" }}>
       <Canvas
@@ -55,7 +40,7 @@ export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia,
 
           <GeometriaSagrada3D
             frecuencia={frecuencia}
-            intensidad={intensidad}
+            activo={activo}
             tipo={tipoGeometria}
           />
 

--- a/components/3d/GeometriaSagrada3D.tsx
+++ b/components/3d/GeometriaSagrada3D.tsx
@@ -6,13 +6,15 @@ import * as THREE from "three";
 
 interface GeometriaSagrada3DProps {
   frecuencia: number;
-  intensidad: number;
+  activo: boolean;
   tipo: "flor-vida" | "merkaba" | "metatron" | "torus";
 }
 
-export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSagrada3DProps) {
+export function GeometriaSagrada3D({ frecuencia, activo, tipo }: GeometriaSagrada3DProps) {
   const grupoRef = useRef<THREE.Group>(null);
   const tiempo = useRef(0);
+  const intensidadRef = useRef(50);
+  const lastUpdateRef = useRef(0);
 
   // ⚡ OPTIMIZACIÓN: Calcular color basado en frecuencia solo cuando cambia
   const colorFrecuencia = useMemo(() => {
@@ -64,8 +66,8 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
   useEffect(() => {
     material.color.set(colorFrecuencia);
     material.emissive.set(colorFrecuencia);
-    material.emissiveIntensity = intensidad / 100;
-  }, [material, colorFrecuencia, intensidad]);
+    // emissiveIntensity is now updated in useFrame
+  }, [material, colorFrecuencia]);
 
   useEffect(() => {
     return () => material.dispose();
@@ -77,13 +79,25 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
 
     tiempo.current += delta;
 
+    // ⚡ BOLT OPTIMIZATION: Move interval logic here to avoid React render cycles
+    if (activo && tiempo.current - lastUpdateRef.current > 2) {
+        lastUpdateRef.current = tiempo.current;
+        const nuevo = intensidadRef.current + (Math.random() - 0.5) * 10;
+        intensidadRef.current = Math.max(30, Math.min(70, nuevo));
+    }
+
+    // Update material directly without causing a React re-render
+    if (material.emissiveIntensity !== intensidadRef.current / 100) {
+        material.emissiveIntensity = intensidadRef.current / 100;
+    }
+
     // Rotación suave basada en la frecuencia
     const velocidad = frecuencia / 10000;
     grupoRef.current.rotation.y += velocidad;
     grupoRef.current.rotation.x = Math.sin(tiempo.current * 0.3) * 0.2;
 
     // Pulsación basada en intensidad
-    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidad / 200);
+    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidadRef.current / 200);
     grupoRef.current.scale.setScalar(escala);
   });
 


### PR DESCRIPTION
💡 **What:** 
Moved the `intensidad` interval state logic out of the parent component (`EscenaMeditacion3D.tsx`) and fully internalised it within the `GeometriaSagrada3D.tsx` `useFrame` hook utilizing `useRef`.

🎯 **Why:** 
Previously, `EscenaMeditacion3D` maintained an `intensidad` value via `useState` and `setInterval` updating every 2 seconds. Every time this state changed, React triggered a re-render of the parent, which caused React Three Fiber to unnecessarily reconcile the entire 3D subtree. While `React.memo` was added, `GeometriaSagrada3D` was still receiving new props, breaking memoization for that subtree.

📊 **Impact:** 
Bypasses the entire React render phase for `intensidad` updates. The 3D scene's internal components now execute independently using raw Three.js mutation, significantly reducing CPU usage and GC pressure during the meditation experience.

🔬 **Measurement:** 
Run `pnpm test` (all tests still pass). Visual confirmation shows the pulsing effect (`emissiveIntensity` and `scale`) works identically to before, but React DevTools will no longer show the parent `EscenaMeditacion3D` re-rendering every 2 seconds.

---
*PR created automatically by Jules for task [10909316850996603376](https://jules.google.com/task/10909316850996603376) started by @mexicodxnmexico-create*