### PR TITLE
🧪 [testing improvement] Add test for QuantumMirror component deviceorientation logic

### DIFF
--- a/tests/quantum-mirror.test.tsx
+++ b/tests/quantum-mirror.test.tsx
@@ -171,6 +171,69 @@ test('QuantumMirror deviceorientation logic', async (t) => {
     });
   });
 
+
+  await t.test('handles partial event values gracefully (only alpha, beta, or gamma)', () => {
+    let root: TestRenderer.ReactTestRenderer | undefined;
+
+    TestRenderer.act(() => {
+      root = TestRenderer.create(<QuantumMirror />);
+    });
+
+    // Dispatch mock deviceorientation event with only alpha
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 10, beta: undefined, gamma: undefined });
+        });
+      }
+    });
+
+    const freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+    const alphaDiv = root!.root.findByProps({ 'data-testid': 'rotation-alpha' });
+    const betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
+    const gammaDiv = root!.root.findByProps({ 'data-testid': 'rotation-gamma' });
+
+    assert.strictEqual(freqDiv.children[0], '432');
+    assert.strictEqual(alphaDiv.children[0], '10');
+    assert.strictEqual(betaDiv.children[0], '0');
+    assert.strictEqual(gammaDiv.children[0], '0');
+
+    // Dispatch mock deviceorientation event with only beta
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: undefined, beta: 20, gamma: undefined });
+        });
+      }
+    });
+
+    assert.strictEqual(freqDiv.children[0], '434'); // 432 + Math.round(20/10) = 434
+    assert.strictEqual(alphaDiv.children[0], '0');
+    assert.strictEqual(betaDiv.children[0], '20');
+    assert.strictEqual(gammaDiv.children[0], '0');
+
+    // Dispatch mock deviceorientation event with only gamma
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: undefined, beta: undefined, gamma: 30 });
+        });
+      }
+    });
+
+    assert.strictEqual(freqDiv.children[0], '432');
+    assert.strictEqual(alphaDiv.children[0], '0');
+    assert.strictEqual(betaDiv.children[0], '0');
+    assert.strictEqual(gammaDiv.children[0], '30');
+
+    TestRenderer.act(() => {
+      root!.unmount();
+    });
+  });
+
   await t.test('removes event listener on unmount', () => {
     let root: TestRenderer.ReactTestRenderer | undefined;
 


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was an unhandled edge case regarding `deviceorientation` event handlers, specifically where partial values (only alpha, beta, or gamma) trigger default fallback values (`e.beta || 0`).

📊 **Coverage:** A new test scenario `handles partial event values gracefully (only alpha, beta, or gamma)` was implemented to explicitly mock and evaluate events that independently set `alpha`, `beta`, or `gamma` to undefined values.

✨ **Result:** Test coverage for `src/components/QuantumMirror.tsx` is now more robust and correctly asserts component behavior on partially constructed orientation event objects, minimizing potential unhandled crashes or regressions. All tests are passing successfully.

---
*PR created automatically by Jules for task [8736482182448543600](https://jules.google.com/task/8736482182448543600) started by @mexicodxnmexico-create*