### PR TITLE
🎨 Palette: Replace makeshift h3 labels with semantic labels in MeditacionAudioVisual3D

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-03-15 - Critical Error State Accessibility
 **Learning:** When a system enters a critical error or collapsed state that disables primary UI interactions, simply rendering the state is insufficient. It requires 'role="alert"' to announce the critical state and explicit focus shifting (via 'autoFocus' or 'useEffect' with 'useRef') to the primary recovery action to maintain accessibility.
 **Action:** Always add 'role="alert"' to error containers and explicitly shift focus to the recovery button or primary text when a disruptive error state mounts.
+
+## 2025-03-22 - Replacing makeshift heading labels with semantic labels
+**Learning:** Using tags like `<h3>` as makeshift labels to style form inputs causes screen reader accessibility to fail because the labels aren't formally associated with the inputs.
+**Action:** Always replace makeshift heading labels with semantic `<label>` tags and add matching `htmlFor` and `id` attributes. Use `display: "block"` and `fontWeight: "bold"` on `<label>` elements to ensure visual styling parity is maintained while still being semantically accessible.

--- a/components/HistorySection.tsx
+++ b/components/HistorySection.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, memo, useMemo } from "react";
+import { CSSProperties, memo } from "react";
 
 const HISTORY_SECTION_STYLE: CSSProperties = { marginBottom: "1.5rem" };
 const LOG_CONTAINER_STYLE: CSSProperties = {

--- a/components/meditacion/MeditacionAudioVisual3D.tsx
+++ b/components/meditacion/MeditacionAudioVisual3D.tsx
@@ -146,10 +146,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="frecuencia" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Frecuencia Solfeggio
-          </h3>
+          </label>
           <select
+            id="frecuencia"
             value={frecuenciaSeleccionada}
             onChange={(e) => setFrecuenciaSeleccionada(Number(e.target.value))}
             disabled={activo}
@@ -176,10 +177,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="geometria" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Geometría Sagrada
-          </h3>
+          </label>
           <select
+            id="geometria"
             value={geometriaSeleccionada}
             onChange={(e) => setGeometriaSeleccionada(e.target.value as any)}
             disabled={activo}
@@ -206,10 +208,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="duracion" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Duración (minutos)
-          </h3>
+          </label>
           <input
+            id="duracion"
             type="number"
             min="1"
             max="60"


### PR DESCRIPTION
💡 **What**: Replaced `<h3>` tags used as makeshift form labels with semantic `<label>` tags and matching `htmlFor` and `id` attributes in the `MeditacionAudioVisual3D` component. Also removed an unused `useMemo` import in `HistorySection.tsx`.

🎯 **Why**: Using heading tags for form labeling breaks accessibility as screen readers cannot properly associate the text with the corresponding input controls. Proper `<label>` elements ensure full keyboard navigation and screen reader support.

📸 **Before/After**: Visually, there is zero difference because the `<label>` elements were styled with `display: "block"` and `fontWeight: "bold"` to match the original `<h3>` appearance.

♿ **Accessibility**: This directly fixes WCAG compliance by ensuring the three form controls (Frecuencia, Geometría, and Duración) have semantically linked labels.

---
*PR created automatically by Jules for task [6868111448294261476](https://jules.google.com/task/6868111448294261476) started by @mexicodxnmexico-create*