### PR TITLE
⚡ Bolt: Internalize 3D animation state to prevent massive canvas re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,7 @@
 ## 2025-06-24 - Efficient Fixed-Size Array Updates
 **Learning:** Using `[...arr, item].slice(-N)` for maintaining a fixed-size buffer causes two array allocations (one for the spread and one for the final slice). While `shift()` is O(n), using `slice()` followed by `push()` and `shift()` is significantly faster because it minimizes heap pressure by avoiding the intermediate array allocation.
 **Action:** Prefer `slice()` + `push()` + `shift()` for more efficient memory management in state transitions.
+
+## 2025-06-25 - Internalizing Rapid 3D Animation State
+**Learning:** In a React Three Fiber setup, driving frequent animation updates (e.g., random walk `intensidad` changing via `setInterval` every 2s) from a parent React component's state causes the entire `<Canvas>` and all its children to re-render. This drastically decreases performance as it defeats the purpose of React Three Fiber's independent update loop.
+**Action:** Internalize animation variables that don't affect standard DOM layout into the 3D components themselves using `useRef` and calculate updates within the `useFrame` loop, mutating `ref.current` values directly and assigning them to Three.js object properties.

--- a/components/3d/EscenaMeditacion3D.tsx
+++ b/components/3d/EscenaMeditacion3D.tsx
@@ -2,7 +2,7 @@
 
 import { Canvas } from "@react-three/fiber";
 import { OrbitControls, Stars, Environment } from "@react-three/drei";
-import { Suspense, useState, useEffect, memo } from "react";
+import { Suspense, memo } from "react";
 import { GeometriaSagrada3D } from "./GeometriaSagrada3D";
 import { ParticulasCuanticas } from "./ParticulasCuanticas";
 
@@ -13,21 +13,10 @@ interface EscenaMeditacion3DProps {
 }
 
 // ⚡ BOLT: Wrap in React.memo to prevent massive 3D canvas re-renders caused by parent 1-second timers
+// ⚡ BOLT OPTIMIZATION: Removed `intensidad` state and `setInterval` from parent.
+// State changes here cause the entire 3D canvas to re-render.
+// The intensity animation is now internalized in `GeometriaSagrada3D.tsx` using useFrame.
 export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia, activo, tipoGeometria }: EscenaMeditacion3DProps) {
-  const [intensidad, setIntensidad] = useState(50);
-
-  useEffect(() => {
-    if (!activo) return;
-
-    const intervalo = setInterval(() => {
-      setIntensidad(prev => {
-        const nuevo = prev + (Math.random() - 0.5) * 10;
-        return Math.max(30, Math.min(70, nuevo));
-      });
-    }, 2000);
-
-    return () => clearInterval(intervalo);
-  }, [activo]);
 
   return (
     <div style={{ width: "100%", height: "600px", borderRadius: "20px", overflow: "hidden" }}>
@@ -55,7 +44,7 @@ export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia,
 
           <GeometriaSagrada3D
             frecuencia={frecuencia}
-            intensidad={intensidad}
+            activo={activo}
             tipo={tipoGeometria}
           />
 

--- a/components/3d/GeometriaSagrada3D.tsx
+++ b/components/3d/GeometriaSagrada3D.tsx
@@ -6,13 +6,17 @@ import * as THREE from "three";
 
 interface GeometriaSagrada3DProps {
   frecuencia: number;
-  intensidad: number;
+  activo: boolean;
   tipo: "flor-vida" | "merkaba" | "metatron" | "torus";
 }
 
-export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSagrada3DProps) {
+export function GeometriaSagrada3D({ frecuencia, activo, tipo }: GeometriaSagrada3DProps) {
   const grupoRef = useRef<THREE.Group>(null);
   const tiempo = useRef(0);
+
+  // ⚡ BOLT OPTIMIZATION: Internalize intensity state to prevent parent re-renders
+  const intensidadRef = useRef(50);
+  const ultimoActualizacionIntensidad = useRef(0);
 
   // ⚡ OPTIMIZACIÓN: Calcular color basado en frecuencia solo cuando cambia
   const colorFrecuencia = useMemo(() => {
@@ -64,8 +68,7 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
   useEffect(() => {
     material.color.set(colorFrecuencia);
     material.emissive.set(colorFrecuencia);
-    material.emissiveIntensity = intensidad / 100;
-  }, [material, colorFrecuencia, intensidad]);
+  }, [material, colorFrecuencia]);
 
   useEffect(() => {
     return () => material.dispose();
@@ -77,13 +80,26 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
 
     tiempo.current += delta;
 
+    // ⚡ BOLT OPTIMIZATION: Internal random walk for intensity
+    // Replaces setInterval in parent component
+    if (activo && tiempo.current - ultimoActualizacionIntensidad.current > 2.0) {
+      const nuevo = intensidadRef.current + (Math.random() - 0.5) * 10;
+      intensidadRef.current = Math.max(30, Math.min(70, nuevo));
+      ultimoActualizacionIntensidad.current = tiempo.current;
+    } else if (!activo) {
+      intensidadRef.current = 50;
+    }
+
     // Rotación suave basada en la frecuencia
     const velocidad = frecuencia / 10000;
     grupoRef.current.rotation.y += velocidad;
     grupoRef.current.rotation.x = Math.sin(tiempo.current * 0.3) * 0.2;
 
+    // Actualizar intensidad del material
+    material.emissiveIntensity = intensidadRef.current / 100;
+
     // Pulsación basada en intensidad
-    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidad / 200);
+    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidadRef.current / 200);
     grupoRef.current.scale.setScalar(escala);
   });
 


### PR DESCRIPTION
💡 **What:** Internalized the `intensidad` state and `setInterval` logic from the parent `EscenaMeditacion3D` React component directly into the `useFrame` hook of `GeometriaSagrada3D`.

🎯 **Why:** The previous implementation used a standard React `useState` and a `setInterval` hook in the parent component to drive a random walk animation for the 3D intensity. This caused the entire Three.js `<Canvas>` and all its children to re-render in the React tree every 2 seconds, which is a significant anti-pattern in React Three Fiber that negates the performance benefits of its independent update loop.

📊 **Impact:** Reduces React tree re-renders for the 3D canvas and its children to near zero during active meditation. The animation logic now runs entirely within the R3F `useFrame` render loop, mutating the properties of the `THREE.Material` and `THREE.Group` directly, resulting in significantly smoother performance and reduced CPU/memory overhead.

🔬 **Measurement:** Use React Developer Tools' Profiler to record a session before and after this change while a meditation is active. The "Render duration" for the `EscenaMeditacion3D` component and its children will drop to zero between parent state changes, with all animation handled cleanly by Three.js.

---
*PR created automatically by Jules for task [15270518924190137515](https://jules.google.com/task/15270518924190137515) started by @mexicodxnmexico-create*