### PR TITLE
🎨 Palette: [UX improvement] Semantic form labels for Meditacion 3D

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-03-15 - Critical Error State Accessibility
 **Learning:** When a system enters a critical error or collapsed state that disables primary UI interactions, simply rendering the state is insufficient. It requires 'role="alert"' to announce the critical state and explicit focus shifting (via 'autoFocus' or 'useEffect' with 'useRef') to the primary recovery action to maintain accessibility.
 **Action:** Always add 'role="alert"' to error containers and explicitly shift focus to the recovery button or primary text when a disruptive error state mounts.
+
+## 2025-03-15 - Semantic Labels vs Heading Tags
+**Learning:** Forms constructed using heading tags (`<h3>`) as visual field descriptors fail screen reader accessibility because they do not semantically associate the text with the corresponding input or select fields.
+**Action:** Always use semantic `<label>` elements with the `htmlFor` attribute mapped directly to the `id` of the form field. Visual styling (e.g., `display: "block"`, `fontWeight: "bold"`) can be applied to the `<label>` to match the intended heading appearance without sacrificing accessibility.

--- a/components/meditacion/MeditacionAudioVisual3D.tsx
+++ b/components/meditacion/MeditacionAudioVisual3D.tsx
@@ -146,10 +146,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="frecuencia" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Frecuencia Solfeggio
-          </h3>
+          </label>
           <select
+            id="frecuencia"
             value={frecuenciaSeleccionada}
             onChange={(e) => setFrecuenciaSeleccionada(Number(e.target.value))}
             disabled={activo}
@@ -176,10 +177,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="geometria" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Geometría Sagrada
-          </h3>
+          </label>
           <select
+            id="geometria"
             value={geometriaSeleccionada}
             onChange={(e) => setGeometriaSeleccionada(e.target.value as any)}
             disabled={activo}
@@ -206,10 +208,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="duracion" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Duración (minutos)
-          </h3>
+          </label>
           <input
+            id="duracion"
             type="number"
             min="1"
             max="60"


### PR DESCRIPTION
💡 **What:**
Replaced the `<h3>` heading tags above the form fields ("Frecuencia Solfeggio", "Geometría Sagrada", "Duración") with semantic `<label>` elements linked via `htmlFor` to the respective `<select>` and `<input>` `id`s. 

🎯 **Why:**
Using headings (`<h3>`) as makeshift labels fails screen reader accessibility because the descriptive text is not semantically associated with the form controls. By using proper `<label>` tags, we ensure that assistive technologies correctly announce the purpose of each field.

📸 **Before/After:**
The visual appearance remains completely identical, as the labels were styled with `display: "block"` and `fontWeight: "bold"` to match the original headings.

♿ **Accessibility:**
Screen readers can now accurately identify the input fields, and users can click the label text to focus the corresponding input or dropdown, improving overall usability.

---
*PR created automatically by Jules for task [10942020557442653072](https://jules.google.com/task/10942020557442653072) started by @mexicodxnmexico-create*