### PR TITLE
🧪 Add explicit zero-value test for QuantumMirror component deviceorientation logic

### DIFF
--- a/tests/quantum-mirror.test.tsx
+++ b/tests/quantum-mirror.test.tsx
@@ -186,4 +186,35 @@ test('QuantumMirror deviceorientation logic', async (t) => {
 
     assert.strictEqual(listeners['deviceorientation'].length, 0);
   });
+
+  await t.test('handles explicit zero values for full branch coverage', () => {
+    let root: TestRenderer.ReactTestRenderer | undefined;
+
+    TestRenderer.act(() => {
+      root = TestRenderer.create(<QuantumMirror />);
+    });
+
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 0, beta: 0, gamma: 0 });
+        });
+      }
+    });
+
+    const freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+    const alphaDiv = root!.root.findByProps({ 'data-testid': 'rotation-alpha' });
+    const betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
+    const gammaDiv = root!.root.findByProps({ 'data-testid': 'rotation-gamma' });
+
+    assert.strictEqual(freqDiv.children[0], '432');
+    assert.strictEqual(alphaDiv.children[0], '0');
+    assert.strictEqual(betaDiv.children[0], '0');
+    assert.strictEqual(gammaDiv.children[0], '0');
+
+    TestRenderer.act(() => {
+      root!.unmount();
+    });
+  });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that the fallback logic inside `QuantumMirror.tsx` (e.g. `e.alpha || 0` and `e.beta ? ... : 0`) was not fully evaluated for implicit JavaScript falsy values like `0`. 

📊 **Coverage:** A new explicit scenario is now tested: Dispatching a `deviceorientation` event with exact values `{ alpha: 0, beta: 0, gamma: 0 }`.

✨ **Result:** Branch coverage for `QuantumMirror.tsx` has improved from `80%` to `80.95%` (the remaining uncovered branches are module import and export compiler artifacts), making the tests more robust against tautological errors.

---
*PR created automatically by Jules for task [8780163665009023942](https://jules.google.com/task/8780163665009023942) started by @mexicodxnmexico-create*