### PR TITLE
🎨 Palette: Use semantic labels for form inputs in 3D Meditation component

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-03-15 - Critical Error State Accessibility
 **Learning:** When a system enters a critical error or collapsed state that disables primary UI interactions, simply rendering the state is insufficient. It requires 'role="alert"' to announce the critical state and explicit focus shifting (via 'autoFocus' or 'useEffect' with 'useRef') to the primary recovery action to maintain accessibility.
 **Action:** Always add 'role="alert"' to error containers and explicitly shift focus to the recovery button or primary text when a disruptive error state mounts.
+
+## 2025-03-22 - Semantic Form Labels in React
+**Learning:** Using `<h3>` tags as makeshift labels for form inputs breaks accessibility for screen reader users because the text is not programmatically associated with the input.
+**Action:** Always use semantic `<label htmlFor="id">` elements mapped directly to the `id` attribute of the corresponding `<input>` or `<select>`, and use CSS (e.g., `display: "block"`, `fontWeight: "bold"`) to match the visual styling of heading tags if needed.

--- a/components/meditacion/MeditacionAudioVisual3D.tsx
+++ b/components/meditacion/MeditacionAudioVisual3D.tsx
@@ -146,10 +146,10 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="frecuencia" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Frecuencia Solfeggio
-          </h3>
-          <select
+          </label>
+          <select id="frecuencia"
             value={frecuenciaSeleccionada}
             onChange={(e) => setFrecuenciaSeleccionada(Number(e.target.value))}
             disabled={activo}
@@ -176,10 +176,10 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="geometria" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Geometría Sagrada
-          </h3>
-          <select
+          </label>
+          <select id="geometria"
             value={geometriaSeleccionada}
             onChange={(e) => setGeometriaSeleccionada(e.target.value as any)}
             disabled={activo}
@@ -206,10 +206,10 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="duracion" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Duración (minutos)
-          </h3>
-          <input
+          </label>
+          <input id="duracion"
             type="number"
             min="1"
             max="60"


### PR DESCRIPTION
### 💡 What
Replaced visually styled `<h3>` tags with semantic `<label htmlFor="...">` tags for the form controls (Frequency, Geometry, Duration) in `MeditacionAudioVisual3D.tsx`.

### 🎯 Why
Screen readers rely on programmatic associations between form labels and inputs to announce controls correctly to visually impaired users. Using a generic `<h3>` tag breaks this connection, resulting in an inaccessible form. The `<label>` elements were styled identically to the previous `<h3>` elements to maintain the visual design while providing the necessary semantic structure.

### 📸 Before/After
*(Visuals remain identical - see attached verification screenshots in pipeline)*

### ♿ Accessibility
- Fixed WCAG compliance for form inputs in the 3D Meditation configuration panel.
- Enabled screen readers to properly announce "Frecuencia Solfeggio", "Geometría Sagrada", and "Duración (minutos)" when users navigate to their respective `<select>` and `<input>` elements.

---
*PR created automatically by Jules for task [14361921619392052364](https://jules.google.com/task/14361921619392052364) started by @mexicodxnmexico-create*