### PR TITLE
🎨 Palette: [Accessibility] Convert heading tags to semantic form labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-03-15 - Critical Error State Accessibility
 **Learning:** When a system enters a critical error or collapsed state that disables primary UI interactions, simply rendering the state is insufficient. It requires 'role="alert"' to announce the critical state and explicit focus shifting (via 'autoFocus' or 'useEffect' with 'useRef') to the primary recovery action to maintain accessibility.
 **Action:** Always add 'role="alert"' to error containers and explicitly shift focus to the recovery button or primary text when a disruptive error state mounts.
+
+## 2025-03-27 - Form Accessibility using Semantic Labels
+**Learning:** Using heading tags like `<h3>` as makeshift labels above form inputs breaks screen reader accessibility by failing to associate the description with the form control.
+**Action:** Always use semantic `<label>` tags with a proper `htmlFor` attribute that matches the `id` of the form element. Visual formatting (e.g., heading-like appearance) should be applied via CSS (e.g., `display: "block"`, `fontWeight: "bold"`) while maintaining semantic correctness.

--- a/components/meditacion/MeditacionAudioVisual3D.tsx
+++ b/components/meditacion/MeditacionAudioVisual3D.tsx
@@ -146,10 +146,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="frecuencia" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Frecuencia Solfeggio
-          </h3>
+          </label>
           <select
+            id="frecuencia"
             value={frecuenciaSeleccionada}
             onChange={(e) => setFrecuenciaSeleccionada(Number(e.target.value))}
             disabled={activo}
@@ -176,10 +177,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="geometria" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Geometría Sagrada
-          </h3>
+          </label>
           <select
+            id="geometria"
             value={geometriaSeleccionada}
             onChange={(e) => setGeometriaSeleccionada(e.target.value as any)}
             disabled={activo}
@@ -206,10 +208,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="duracion" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Duración (minutos)
-          </h3>
+          </label>
           <input
+            id="duracion"
             type="number"
             min="1"
             max="60"


### PR DESCRIPTION
**💡 What:** 
Replaced non-semantic `<h3>` headings used as makeshift form labels with proper `<label>` elements in `components/meditacion/MeditacionAudioVisual3D.tsx`. Added `htmlFor` and `id` attributes to correctly link the labels to their corresponding `<select>` and `<input>` controls. Maintained the visual appearance by adding `display: "block"` and `fontWeight: "bold"` inline styles.

**🎯 Why:**
Using heading tags to visually label form inputs breaks screen reader functionality, as the assistive technology does not properly associate the preceding text with the form control. By using semantic `<label>` elements, we provide an accessible name for each input, making the form fully navigable and understandable for screen reader users.

**📸 Before/After:**
The visual appearance is identical (bold text above the input). The underlying DOM structure was updated from `<h3>Label</h3><input />` to `<label htmlFor="id">Label</label><input id="id" />`.

**♿ Accessibility:**
Greatly improved screen reader support by providing explicit, programmatic associations between labels and form controls, adhering to WCAG guidelines for form accessibility.

---
*PR created automatically by Jules for task [14330802328149912415](https://jules.google.com/task/14330802328149912415) started by @mexicodxnmexico-create*