### PR TITLE
🎨 Palette: Replace makeshift h3 labels with semantic label tags

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-03-15 - Critical Error State Accessibility
 **Learning:** When a system enters a critical error or collapsed state that disables primary UI interactions, simply rendering the state is insufficient. It requires 'role="alert"' to announce the critical state and explicit focus shifting (via 'autoFocus' or 'useEffect' with 'useRef') to the primary recovery action to maintain accessibility.
 **Action:** Always add 'role="alert"' to error containers and explicitly shift focus to the recovery button or primary text when a disruptive error state mounts.
+
+## 2024-05-18 - Semantic labels for accessibility
+**Learning:** Using `<h3>` (or other heading elements) as makeshift labels for form controls creates accessibility issues because screen readers cannot properly associate the label text with the form input.
+**Action:** Always use semantic `<label>` tags with a `htmlFor` attribute that strictly matches the `id` of the corresponding `<input>`, `<select>`, or `<textarea>`. To preserve visual parity from previous heading usage, utilize inline styles like `display: "block"` and matching font weights.

--- a/components/meditacion/MeditacionAudioVisual3D.tsx
+++ b/components/meditacion/MeditacionAudioVisual3D.tsx
@@ -146,10 +146,10 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="frecuencia" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Frecuencia Solfeggio
-          </h3>
-          <select
+          </label>
+          <select id="frecuencia"
             value={frecuenciaSeleccionada}
             onChange={(e) => setFrecuenciaSeleccionada(Number(e.target.value))}
             disabled={activo}
@@ -176,10 +176,10 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="geometria" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Geometría Sagrada
-          </h3>
-          <select
+          </label>
+          <select id="geometria"
             value={geometriaSeleccionada}
             onChange={(e) => setGeometriaSeleccionada(e.target.value as any)}
             disabled={activo}
@@ -206,10 +206,10 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="duracion" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Duración (minutos)
-          </h3>
-          <input
+          </label>
+          <input id="duracion"
             type="number"
             min="1"
             max="60"


### PR DESCRIPTION
💡 **What**: Replaced `<h3>` headings used as makeshift labels with semantic `<label>` tags for the "Frecuencia Solfeggio", "Geometría Sagrada", and "Duración (minutos)" form controls in the `MeditacionAudioVisual3D` component.
🎯 **Why**: Using heading elements (`<h3>`) as visual labels prevents screen readers from properly associating the label text with the corresponding input or select elements, making the form difficult or impossible to navigate for users relying on assistive technology.
📸 **Before/After**: Visually identical. `<h3>` tags with 1rem font size and 1rem margin-bottom were swapped for `<label>` tags with `display: "block"`, `fontWeight: "bold"`, 1rem font size, and 1rem margin-bottom.
♿ **Accessibility**: Significant improvement. The new `<label>` elements use the `htmlFor` attribute to explicitly link to the `id` of their respective `<select>` or `<input>` controls, ensuring screen readers announce the correct label when the user focuses on the field. Clicking the text now also focuses the corresponding input.

---
*PR created automatically by Jules for task [12328881803400238131](https://jules.google.com/task/12328881803400238131) started by @mexicodxnmexico-create*