### PR TITLE
🧪 Improve QuantumMirror deviceorientation test coverage

### DIFF
--- a/tests/quantum-mirror.test.tsx
+++ b/tests/quantum-mirror.test.tsx
@@ -146,7 +146,27 @@ test('QuantumMirror deviceorientation logic', async (t) => {
       root = TestRenderer.create(<QuantumMirror />);
     });
 
-    // Dispatch mock deviceorientation event with null/undefined values
+    const freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+    const alphaDiv = root!.root.findByProps({ 'data-testid': 'rotation-alpha' });
+    const betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
+    const gammaDiv = root!.root.findByProps({ 'data-testid': 'rotation-gamma' });
+
+    // First, set to non-zero values to avoid tautological tests
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 10, beta: 20, gamma: 30 });
+        });
+      }
+    });
+
+    assert.strictEqual(freqDiv.children[0], '434'); // 432 + Math.round(20 / 10)
+    assert.strictEqual(alphaDiv.children[0], '10');
+    assert.strictEqual(betaDiv.children[0], '20');
+    assert.strictEqual(gammaDiv.children[0], '30');
+
+    // Then, dispatch mock deviceorientation event with null/undefined values
     TestRenderer.act(() => {
       const orientationListeners = listeners['deviceorientation'];
       if (orientationListeners) {
@@ -155,11 +175,6 @@ test('QuantumMirror deviceorientation logic', async (t) => {
         });
       }
     });
-
-    const freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
-    const alphaDiv = root!.root.findByProps({ 'data-testid': 'rotation-alpha' });
-    const betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
-    const gammaDiv = root!.root.findByProps({ 'data-testid': 'rotation-gamma' });
 
     assert.strictEqual(freqDiv.children[0], '432');
     assert.strictEqual(alphaDiv.children[0], '0');


### PR DESCRIPTION
🎯 **What:** The existing test for handling missing `deviceorientation` event values in `QuantumMirror.tsx` was somewhat tautological. It dispatched `null` values to a freshly initialized component (where state was already `0`) and asserted the state remained `0`. This didn't properly verify the fallback logic (`e.alpha || 0`) inside the listener because a failure to update state would also yield `0`.

📊 **Coverage:** The test now verifies that if the component has *non-zero* rotation/frequency state (from a prior valid event), a subsequent event with missing values (`null` or `undefined`) correctly triggers the fallback logic to reset the rotation state to `0` and frequency to `432`.

✨ **Result:** Improved test reliability. The test now genuinely verifies that the missing value fallback logic within the event handler actually executes and applies the defaults, rather than just silently failing or relying on the initial state.

---
*PR created automatically by Jules for task [11247708122916163820](https://jules.google.com/task/11247708122916163820) started by @mexicodxnmexico-create*