### PR TITLE
⚡ Bolt: Internalize 3D intensity random walk in GeometriaSagrada3D

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,7 @@
 ## 2025-06-24 - Efficient Fixed-Size Array Updates
 **Learning:** Using `[...arr, item].slice(-N)` for maintaining a fixed-size buffer causes two array allocations (one for the spread and one for the final slice). While `shift()` is O(n), using `slice()` followed by `push()` and `shift()` is significantly faster because it minimizes heap pressure by avoiding the intermediate array allocation.
 **Action:** Prefer `slice()` + `push()` + `shift()` for more efficient memory management in state transitions.
+
+## 2025-07-15 - Internalizing 3D Animation State in useFrame
+**Learning:** Managing rapidly changing animation variables (like a random walk for light intensity) in parent React state causes the entire 3D scene (including the Canvas and all its children) to re-render via the React reconciliation cycle. This is extremely expensive in R3F.
+**Action:** Internalize such variables in the leaf component using `useRef` and perform updates directly on the Three.js objects (e.g., `material.emissiveIntensity`) within the `useFrame` loop. Use `state.clock.elapsedTime` to throttle updates, bypassing React re-renders entirely for frame-by-frame visual changes.

--- a/components/3d/EscenaMeditacion3D.tsx
+++ b/components/3d/EscenaMeditacion3D.tsx
@@ -2,7 +2,7 @@
 
 import { Canvas } from "@react-three/fiber";
 import { OrbitControls, Stars, Environment } from "@react-three/drei";
-import { Suspense, useState, useEffect, memo } from "react";
+import { Suspense, memo } from "react";
 import { GeometriaSagrada3D } from "./GeometriaSagrada3D";
 import { ParticulasCuanticas } from "./ParticulasCuanticas";
 
@@ -14,20 +14,8 @@ interface EscenaMeditacion3DProps {
 
 // ⚡ BOLT: Wrap in React.memo to prevent massive 3D canvas re-renders caused by parent 1-second timers
 export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia, activo, tipoGeometria }: EscenaMeditacion3DProps) {
-  const [intensidad, setIntensidad] = useState(50);
-
-  useEffect(() => {
-    if (!activo) return;
-
-    const intervalo = setInterval(() => {
-      setIntensidad(prev => {
-        const nuevo = prev + (Math.random() - 0.5) * 10;
-        return Math.max(30, Math.min(70, nuevo));
-      });
-    }, 2000);
-
-    return () => clearInterval(intervalo);
-  }, [activo]);
+  // ⚡ BOLT: 'intensidad' state removed and internalized within GeometriaSagrada3D
+  // to prevent re-rendering the entire 3D scene every 2 seconds.
 
   return (
     <div style={{ width: "100%", height: "600px", borderRadius: "20px", overflow: "hidden" }}>
@@ -55,8 +43,8 @@ export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia,
 
           <GeometriaSagrada3D
             frecuencia={frecuencia}
-            intensidad={intensidad}
             tipo={tipoGeometria}
+            activo={activo}
           />
 
           <ParticulasCuanticas

--- a/components/3d/GeometriaSagrada3D.tsx
+++ b/components/3d/GeometriaSagrada3D.tsx
@@ -6,13 +6,17 @@ import * as THREE from "three";
 
 interface GeometriaSagrada3DProps {
   frecuencia: number;
-  intensidad: number;
   tipo: "flor-vida" | "merkaba" | "metatron" | "torus";
+  activo: boolean;
 }
 
-export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSagrada3DProps) {
+export function GeometriaSagrada3D({ frecuencia, tipo, activo }: GeometriaSagrada3DProps) {
   const grupoRef = useRef<THREE.Group>(null);
   const tiempo = useRef(0);
+
+  // ⚡ BOLT: Internalize intensity random walk to avoid expensive parent re-renders
+  const intensidadRef = useRef(50);
+  const ultimoUpdateIntensidad = useRef(0);
 
   // ⚡ OPTIMIZACIÓN: Calcular color basado en frecuencia solo cuando cambia
   const colorFrecuencia = useMemo(() => {
@@ -64,18 +68,27 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
   useEffect(() => {
     material.color.set(colorFrecuencia);
     material.emissive.set(colorFrecuencia);
-    material.emissiveIntensity = intensidad / 100;
-  }, [material, colorFrecuencia, intensidad]);
+    material.emissiveIntensity = intensidadRef.current / 100;
+  }, [material, colorFrecuencia]);
 
   useEffect(() => {
     return () => material.dispose();
   }, [material]);
 
   // Animación continua
-  useFrame((_state, delta) => {
+  useFrame((state, delta) => {
     if (!grupoRef.current) return;
 
     tiempo.current += delta;
+    const t = state.clock.elapsedTime;
+
+    // ⚡ BOLT: Throttle intensity random walk to once every 2 seconds within useFrame
+    if (activo && t - ultimoUpdateIntensidad.current > 2) {
+      const nuevo = intensidadRef.current + (Math.random() - 0.5) * 10;
+      intensidadRef.current = Math.max(30, Math.min(70, nuevo));
+      material.emissiveIntensity = intensidadRef.current / 100;
+      ultimoUpdateIntensidad.current = t;
+    }
 
     // Rotación suave basada en la frecuencia
     const velocidad = frecuencia / 10000;
@@ -83,7 +96,7 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
     grupoRef.current.rotation.x = Math.sin(tiempo.current * 0.3) * 0.2;
 
     // Pulsación basada en intensidad
-    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidad / 200);
+    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidadRef.current / 200);
     grupoRef.current.scale.setScalar(escala);
   });
 


### PR DESCRIPTION
### 💡 What
Internalized the `intensidad` random walk logic within the `GeometriaSagrada3D` component using `useRef` and `useFrame`. Removed the corresponding React state and `setInterval` from the parent `EscenaMeditacion3D` component.

### 🎯 Why
In React Three Fiber, managing rapidly changing animation variables in React state causes the entire 3D scene tree (including the `Canvas` and all its children) to re-render via the React reconciliation cycle. This is extremely expensive and unnecessary for visual updates that can be applied directly to Three.js objects.

### 📊 Impact
- **Reduces Re-renders:** Eliminates a full scene re-render every 2 seconds during meditation.
- **Lower CPU Usage:** Bypasses the React diffing and reconciliation process for frame-by-frame material updates.
- **Smoother Performance:** Ensures that visual pulsations and emissive intensity changes are handled within the R3F animation loop, resulting in more consistent frame rates.

### 🔬 Measurement
- Verified that `EscenaMeditacion3D` no longer manages the `intensidad` state.
- Confirmed `GeometriaSagrada3D` uses `useRef` to maintain the random walk value and updates `material.emissiveIntensity` directly within `useFrame`.
- All repository tests passed successfully after restoring the environment with `pnpm install`.
- Verified that `tsconfig.json` and `next-env.d.ts` were restored to their original state to maintain project hygiene.

---
*PR created automatically by Jules for task [2837307382269705951](https://jules.google.com/task/2837307382269705951) started by @mexicodxnmexico-create*