### PR TITLE
🎨 Palette: Improve form accessibility in MeditacionAudioVisual3D

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-03-15 - Critical Error State Accessibility
 **Learning:** When a system enters a critical error or collapsed state that disables primary UI interactions, simply rendering the state is insufficient. It requires 'role="alert"' to announce the critical state and explicit focus shifting (via 'autoFocus' or 'useEffect' with 'useRef') to the primary recovery action to maintain accessibility.
 **Action:** Always add 'role="alert"' to error containers and explicitly shift focus to the recovery button or primary text when a disruptive error state mounts.
+
+## 2025-03-29 - Semantic Form Labels vs Visual Headers
+**Learning:** Screen readers cannot associate block-level visual headers (e.g., `<h3>`) with adjacent form inputs, leaving the inputs inaccessible.
+**Action:** Always replace makeshift `<h3>` form headers with semantic `<label htmlFor="...">` tags mapped to the input's `id`. To maintain visual parity without breaking screen reader support, apply `display: "block"` and match the previous typography (e.g., `fontWeight: "bold"`).

--- a/components/meditacion/MeditacionAudioVisual3D.tsx
+++ b/components/meditacion/MeditacionAudioVisual3D.tsx
@@ -146,10 +146,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="frecuencia" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Frecuencia Solfeggio
-          </h3>
+          </label>
           <select
+            id="frecuencia"
             value={frecuenciaSeleccionada}
             onChange={(e) => setFrecuenciaSeleccionada(Number(e.target.value))}
             disabled={activo}
@@ -176,10 +177,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="geometria" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Geometría Sagrada
-          </h3>
+          </label>
           <select
+            id="geometria"
             value={geometriaSeleccionada}
             onChange={(e) => setGeometriaSeleccionada(e.target.value as any)}
             disabled={activo}
@@ -206,10 +208,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="duracion" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Duración (minutos)
-          </h3>
+          </label>
           <input
+            id="duracion"
             type="number"
             min="1"
             max="60"


### PR DESCRIPTION
💡 **What**
Replaced the `<h3>` visual headers in the `MeditacionAudioVisual3D.tsx` configuration panel with proper semantic `<label>` elements linked to their respective inputs (`select` and `input`) using `htmlFor` and `id` attributes. Added styling (`display: "block"`, `fontWeight: "bold"`) to perfectly match the previous `<h3>` appearance.

🎯 **Why**
Using block-level heading elements like `<h3>` as makeshift labels prevents screen readers from understanding the context of the adjacent form inputs, leaving those controls largely inaccessible. Semantic `<label>` elements provide explicit linkage, enabling assistive technologies to properly announce the input's purpose. It also adds the native web capability to focus the input by clicking on the label text itself.

📸 **Before/After**
Visually identical. Functionally, clicking the text "Frecuencia Solfeggio", "Geometría Sagrada", or "Duración (minutos)" now focuses the adjacent input control.

♿ **Accessibility**
- Screen reader users can now hear the label when interacting with the frequency select, geometry select, and duration input fields.
- Increases hit-area for mouse users as clicking the label sets focus to the target control.

---
*PR created automatically by Jules for task [6235685974089443056](https://jules.google.com/task/6235685974089443056) started by @mexicodxnmexico-create*