### PR TITLE
🧪 Improve coverage for QuantumMirror zero-value fallbacks

### DIFF
--- a/tests/quantum-mirror.test.tsx
+++ b/tests/quantum-mirror.test.tsx
@@ -171,6 +171,51 @@ test('QuantumMirror deviceorientation logic', async (t) => {
     });
   });
 
+
+  await t.test('explicitly handles zero values for all axes', () => {
+    let root: TestRenderer.ReactTestRenderer | undefined;
+
+    // First transition to a non-zero state to ensure we are actually testing a state change to 0
+    TestRenderer.act(() => {
+      root = TestRenderer.create(<QuantumMirror />);
+    });
+
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach((listener: Function) => {
+          listener({ alpha: 10, beta: 10, gamma: 10 });
+        });
+      }
+    });
+
+    const alphaDiv = root!.root.findByProps({ 'data-testid': 'rotation-alpha' });
+    const betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
+    const gammaDiv = root!.root.findByProps({ 'data-testid': 'rotation-gamma' });
+
+    assert.strictEqual(alphaDiv.children[0], '10');
+    assert.strictEqual(betaDiv.children[0], '10');
+    assert.strictEqual(gammaDiv.children[0], '10');
+
+    // Now dispatch 0 values to test fallback logic e.g. e.alpha || 0
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach((listener: Function) => {
+          listener({ alpha: 0, beta: 0, gamma: 0 });
+        });
+      }
+    });
+
+    assert.strictEqual(alphaDiv.children[0], '0');
+    assert.strictEqual(betaDiv.children[0], '0');
+    assert.strictEqual(gammaDiv.children[0], '0');
+
+    TestRenderer.act(() => {
+      root!.unmount();
+    });
+  });
+
   await t.test('removes event listener on unmount', () => {
     let root: TestRenderer.ReactTestRenderer | undefined;
 


### PR DESCRIPTION
🎯 **What:** The existing test suite for `QuantumMirror.tsx` adequately covered positive, negative, missing (`null`/`undefined`) mock `deviceorientation` events. However, the condition for fallback values in `e.alpha || 0` was not explicitly verified using precisely `0` values for all axes during a mock orientation event, missing a nuanced branch coverage scenario on the component's internal logic.

📊 **Coverage:** A new test case explicitly passes `{ alpha: 0, beta: 0, gamma: 0 }` to `deviceorientation` listeners. This rigorously validates that the React state gracefully falls back to `0` exactly as intended by the falsy short-circuit expression when absolute zero values are reported from the hardware sensor. 

✨ **Result:** Test coverage for the `deviceorientation` branch logic handling `0` states directly matches the expected structural robustness. Overall test suite reliability increases for potential edge-case regressions.

---
*PR created automatically by Jules for task [1052225897018463345](https://jules.google.com/task/1052225897018463345) started by @mexicodxnmexico-create*