### PR TITLE
⚡ Bolt: Internalize 3D animation state to prevent parent re-renders

### DIFF
--- a/components/3d/EscenaMeditacion3D.tsx
+++ b/components/3d/EscenaMeditacion3D.tsx
@@ -2,7 +2,7 @@
 
 import { Canvas } from "@react-three/fiber";
 import { OrbitControls, Stars, Environment } from "@react-three/drei";
-import { Suspense, useState, useEffect, memo } from "react";
+import { Suspense, memo } from "react";
 import { GeometriaSagrada3D } from "./GeometriaSagrada3D";
 import { ParticulasCuanticas } from "./ParticulasCuanticas";
 
@@ -14,21 +14,6 @@ interface EscenaMeditacion3DProps {
 
 // ⚡ BOLT: Wrap in React.memo to prevent massive 3D canvas re-renders caused by parent 1-second timers
 export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia, activo, tipoGeometria }: EscenaMeditacion3DProps) {
-  const [intensidad, setIntensidad] = useState(50);
-
-  useEffect(() => {
-    if (!activo) return;
-
-    const intervalo = setInterval(() => {
-      setIntensidad(prev => {
-        const nuevo = prev + (Math.random() - 0.5) * 10;
-        return Math.max(30, Math.min(70, nuevo));
-      });
-    }, 2000);
-
-    return () => clearInterval(intervalo);
-  }, [activo]);
-
   return (
     <div style={{ width: "100%", height: "600px", borderRadius: "20px", overflow: "hidden" }}>
       <Canvas
@@ -55,7 +40,7 @@ export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia,
 
           <GeometriaSagrada3D
             frecuencia={frecuencia}
-            intensidad={intensidad}
+            activo={activo}
             tipo={tipoGeometria}
           />
 

--- a/components/3d/GeometriaSagrada3D.tsx
+++ b/components/3d/GeometriaSagrada3D.tsx
@@ -6,13 +6,16 @@ import * as THREE from "three";
 
 interface GeometriaSagrada3DProps {
   frecuencia: number;
-  intensidad: number;
+  activo: boolean;
   tipo: "flor-vida" | "merkaba" | "metatron" | "torus";
 }
 
-export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSagrada3DProps) {
+export function GeometriaSagrada3D({ frecuencia, activo, tipo }: GeometriaSagrada3DProps) {
   const grupoRef = useRef<THREE.Group>(null);
   const tiempo = useRef(0);
+  // ⚡ BOLT: Internalize intensity state to prevent parent re-renders
+  const intensidadRef = useRef(50);
+  const lastUpdateRef = useRef(0);
 
   // ⚡ OPTIMIZACIÓN: Calcular color basado en frecuencia solo cuando cambia
   const colorFrecuencia = useMemo(() => {
@@ -64,18 +67,29 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
   useEffect(() => {
     material.color.set(colorFrecuencia);
     material.emissive.set(colorFrecuencia);
-    material.emissiveIntensity = intensidad / 100;
-  }, [material, colorFrecuencia, intensidad]);
+  }, [material, colorFrecuencia]);
 
   useEffect(() => {
     return () => material.dispose();
   }, [material]);
 
   // Animación continua
-  useFrame((_state, delta) => {
+  useFrame((state, delta) => {
     if (!grupoRef.current) return;
 
     tiempo.current += delta;
+
+    // ⚡ BOLT: Calculate intensity internally without triggering React renders
+    if (activo) {
+      if (state.clock.elapsedTime - lastUpdateRef.current > 2) {
+        const nuevo = intensidadRef.current + (Math.random() - 0.5) * 10;
+        intensidadRef.current = Math.max(30, Math.min(70, nuevo));
+        lastUpdateRef.current = state.clock.elapsedTime;
+      }
+    }
+
+    // Apply intensity directly to material bypassing React
+    material.emissiveIntensity = intensidadRef.current / 100;
 
     // Rotación suave basada en la frecuencia
     const velocidad = frecuencia / 10000;
@@ -83,7 +97,7 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
     grupoRef.current.rotation.x = Math.sin(tiempo.current * 0.3) * 0.2;
 
     // Pulsación basada en intensidad
-    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidad / 200);
+    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidadRef.current / 200);
     grupoRef.current.scale.setScalar(escala);
   });
 


### PR DESCRIPTION
💡 **What**: Refactored the `EscenaMeditacion3D` and `GeometriaSagrada3D` components. Removed the `useState` and 2-second `setInterval` that managed the random `intensidad` value in the parent component (`EscenaMeditacion3D`). Instead, moved this logic into a `useRef` within the `useFrame` loop of the child component (`GeometriaSagrada3D`). The updated intensity directly manipulates the `material.emissiveIntensity` and `mesh.scale` properties, completely bypassing React reconciliation.

🎯 **Why**: When `intensidad` was a state variable in the parent, the 2-second `setInterval` triggered a re-render of the entire `EscenaMeditacion3D` component, including the expensive React Three Fiber `<Canvas>`, `<Stars>`, `<ParticulasCuanticas>`, etc. This created significant, unnecessary garbage collection pressure and could cause frame drops in a high-performance 3D scene. By internalizing the state in the child component's render loop, we avoid triggering the React component lifecycle entirely for these frequent animation updates.

📊 **Impact**: Reduces parent component re-renders by 100% while the meditation is active. The `EscenaMeditacion3D` now only re-renders when the user explicitly changes the frequency or geometry in the control panel. The random intensity updates are now purely WebGL/Three.js updates.

🔬 **Measurement**: Start the meditation and observe the React DevTools Profiler. Previously, there would be a render cycle every 2 seconds for the entire 3D scene. Now, there should be zero renders logged by React while the meditation is running.

---
*PR created automatically by Jules for task [794847141900764496](https://jules.google.com/task/794847141900764496) started by @mexicodxnmexico-create*