### PR TITLE
🎨 Palette: Replace h3 with semantic labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,6 @@
 ## 2025-03-15 - Critical Error State Accessibility
 **Learning:** When a system enters a critical error or collapsed state that disables primary UI interactions, simply rendering the state is insufficient. It requires 'role="alert"' to announce the critical state and explicit focus shifting (via 'autoFocus' or 'useEffect' with 'useRef') to the primary recovery action to maintain accessibility.
 **Action:** Always add 'role="alert"' to error containers and explicitly shift focus to the recovery button or primary text when a disruptive error state mounts.
+## 2024-05-28 - Avoid using headings as makeshift labels
+**Learning:** Using heading tags (`<h3>`, `<h4>`, etc.) as labels for form inputs causes screen readers to misinterpret the structure and context of the inputs, resulting in an inaccessible form experience.
+**Action:** Always use semantic `<label>` tags linked to input fields via the `htmlFor` and `id` attributes. If visual heading styles are required, apply CSS to the `<label>` tag directly rather than using a heading tag.

--- a/components/meditacion/MeditacionAudioVisual3D.tsx
+++ b/components/meditacion/MeditacionAudioVisual3D.tsx
@@ -146,10 +146,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="frecuencia" style={{ display: "block", fontSize: "1rem", marginBottom: "1rem", color: "#333", fontWeight: "bold" }}>
             Frecuencia Solfeggio
-          </h3>
+          </label>
           <select
+            id="frecuencia"
             value={frecuenciaSeleccionada}
             onChange={(e) => setFrecuenciaSeleccionada(Number(e.target.value))}
             disabled={activo}
@@ -176,10 +177,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="geometria" style={{ display: "block", fontSize: "1rem", marginBottom: "1rem", color: "#333", fontWeight: "bold" }}>
             Geometría Sagrada
-          </h3>
+          </label>
           <select
+            id="geometria"
             value={geometriaSeleccionada}
             onChange={(e) => setGeometriaSeleccionada(e.target.value as any)}
             disabled={activo}
@@ -206,10 +208,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="duracion" style={{ display: "block", fontSize: "1rem", marginBottom: "1rem", color: "#333", fontWeight: "bold" }}>
             Duración (minutos)
-          </h3>
+          </label>
           <input
+            id="duracion"
             type="number"
             min="1"
             max="60"


### PR DESCRIPTION
### 💡 What
Replaced visually styled `<h3>` tags that were acting as form block headers with semantic `<label>` elements in `components/meditacion/MeditacionAudioVisual3D.tsx`.

### 🎯 Why
Using heading tags (`<h3>`) as form labels creates an inaccessible experience for screen reader users, who rely on proper semantic relationships (`<label htmlFor="...">`) to understand what input corresponds to what field. This fix improves structure while maintaining exact visual parity.

### 📸 Before/After
*Before:* `<h3>` tags with `Frecuencia Solfeggio`, etc.
*After:* Semantic `<label htmlFor="frecuencia">` and `<select id="frecuencia">`.

### ♿ Accessibility
- Ensures all form inputs (`Frecuencia Solfeggio`, `Geometría Sagrada`, `Duración`) are properly announced by screen readers alongside their context.
- Logged this critical learning pattern into the Palette journal.

---
*PR created automatically by Jules for task [204722264720936596](https://jules.google.com/task/204722264720936596) started by @mexicodxnmexico-create*