### PR TITLE
⚡ Bolt: Internalize 3D animation state to avoid React re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,7 @@
 ## 2025-06-24 - Efficient Fixed-Size Array Updates
 **Learning:** Using `[...arr, item].slice(-N)` for maintaining a fixed-size buffer causes two array allocations (one for the spread and one for the final slice). While `shift()` is O(n), using `slice()` followed by `push()` and `shift()` is significantly faster because it minimizes heap pressure by avoiding the intermediate array allocation.
 **Action:** Prefer `slice()` + `push()` + `shift()` for more efficient memory management in state transitions.
+
+## 2025-06-25 - Internalizing high-frequency animation state
+**Learning:** Moving animation state (like random walk intensity) from parent React state into a child's `useRef` within a `useFrame` loop significantly improves performance by bypassing React's reconciliation and re-rendering cycle for the entire 3D scene (including the Canvas and all its siblings).
+**Action:** Always internalize high-frequency or periodic state updates within the React Three Fiber `useFrame` loop when the state only affects visual properties that can be updated directly via Three.js objects.

--- a/components/3d/EscenaMeditacion3D.tsx
+++ b/components/3d/EscenaMeditacion3D.tsx
@@ -14,21 +14,6 @@ interface EscenaMeditacion3DProps {
 
 // ⚡ BOLT: Wrap in React.memo to prevent massive 3D canvas re-renders caused by parent 1-second timers
 export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia, activo, tipoGeometria }: EscenaMeditacion3DProps) {
-  const [intensidad, setIntensidad] = useState(50);
-
-  useEffect(() => {
-    if (!activo) return;
-
-    const intervalo = setInterval(() => {
-      setIntensidad(prev => {
-        const nuevo = prev + (Math.random() - 0.5) * 10;
-        return Math.max(30, Math.min(70, nuevo));
-      });
-    }, 2000);
-
-    return () => clearInterval(intervalo);
-  }, [activo]);
-
   return (
     <div style={{ width: "100%", height: "600px", borderRadius: "20px", overflow: "hidden" }}>
       <Canvas
@@ -55,7 +40,7 @@ export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia,
 
           <GeometriaSagrada3D
             frecuencia={frecuencia}
-            intensidad={intensidad}
+            activo={activo}
             tipo={tipoGeometria}
           />
 

--- a/components/3d/GeometriaSagrada3D.tsx
+++ b/components/3d/GeometriaSagrada3D.tsx
@@ -6,13 +6,15 @@ import * as THREE from "three";
 
 interface GeometriaSagrada3DProps {
   frecuencia: number;
-  intensidad: number;
+  activo: boolean;
   tipo: "flor-vida" | "merkaba" | "metatron" | "torus";
 }
 
-export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSagrada3DProps) {
+export function GeometriaSagrada3D({ frecuencia, activo, tipo }: GeometriaSagrada3DProps) {
   const grupoRef = useRef<THREE.Group>(null);
   const tiempo = useRef(0);
+  const intensidad = useRef(50);
+  const ultimoSalto = useRef(0);
 
   // ⚡ OPTIMIZACIÓN: Calcular color basado en frecuencia solo cuando cambia
   const colorFrecuencia = useMemo(() => {
@@ -64,18 +66,26 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
   useEffect(() => {
     material.color.set(colorFrecuencia);
     material.emissive.set(colorFrecuencia);
-    material.emissiveIntensity = intensidad / 100;
-  }, [material, colorFrecuencia, intensidad]);
+    material.emissiveIntensity = intensidad.current / 100;
+  }, [material, colorFrecuencia]);
 
   useEffect(() => {
     return () => material.dispose();
   }, [material]);
 
   // Animación continua
-  useFrame((_state, delta) => {
+  useFrame((state, delta) => {
     if (!grupoRef.current) return;
 
     tiempo.current += delta;
+
+    // ⚡ BOLT: Move random walk intensity logic here to avoid React re-renders.
+    // Throttled to every 2 seconds to match original logic.
+    if (activo && state.clock.elapsedTime - ultimoSalto.current > 2) {
+      intensidad.current += (Math.random() - 0.5) * 10;
+      intensidad.current = Math.max(30, Math.min(70, intensidad.current));
+      ultimoSalto.current = state.clock.elapsedTime;
+    }
 
     // Rotación suave basada en la frecuencia
     const velocidad = frecuencia / 10000;
@@ -83,8 +93,13 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
     grupoRef.current.rotation.x = Math.sin(tiempo.current * 0.3) * 0.2;
 
     // Pulsación basada en intensidad
-    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidad / 200);
+    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidad.current / 200);
     grupoRef.current.scale.setScalar(escala);
+
+    // ⚡ BOLT: Update material property directly in the frame loop
+    if (material) {
+      material.emissiveIntensity = intensidad.current / 100;
+    }
   });
 
   return (


### PR DESCRIPTION
💡 **What**: Optimized the 3D meditation scene by internalizing the `intensidad` animation state. Previously, this was managed as React state in `EscenaMeditacion3D` and updated via `setInterval` every 2 seconds, triggering a full component re-render. It is now managed via `useRef` inside `GeometriaSagrada3D` and updated directly within the React Three Fiber `useFrame` loop.

🎯 **Why**: React re-renders are expensive for heavy components like the 3D `<Canvas>`. Updating visual properties (like scale and emissive intensity) directly on Three.js objects within the frame loop is significantly more efficient than going through React's reconciliation cycle.

📊 **Impact**: Reduces React re-renders of the 3D scene from once every 2 seconds to zero during active meditation. This lowers CPU overhead and prevents potential UI stutters on lower-end devices.

🔬 **Measurement**: Can be verified by adding a `console.log` in the `EscenaMeditacion3D` render function; it should no longer fire periodically while the meditation is active. Visual parity is maintained by replicating the 2-second random walk logic using `state.clock.elapsedTime` in the frame loop.

---
*PR created automatically by Jules for task [5341861903225141872](https://jules.google.com/task/5341861903225141872) started by @mexicodxnmexico-create*