### PR TITLE
⚡ Bolt: Optimize 3D re-renders by internalizing animation state

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,7 @@
 ## 2025-06-24 - Efficient Fixed-Size Array Updates
 **Learning:** Using `[...arr, item].slice(-N)` for maintaining a fixed-size buffer causes two array allocations (one for the spread and one for the final slice). While `shift()` is O(n), using `slice()` followed by `push()` and `shift()` is significantly faster because it minimizes heap pressure by avoiding the intermediate array allocation.
 **Action:** Prefer `slice()` + `push()` + `shift()` for more efficient memory management in state transitions.
+
+## 2025-06-25 - React re-renders and R3F animations
+**Learning:** Using `useState` and `setInterval` in a parent component (like `EscenaMeditacion3D.tsx`) to update variables that drive constant 3D animation (like intensity) forces the entire React component tree for the 3D scene to re-render constantly. This is a severe performance bottleneck.
+**Action:** Internalize the logic within the child component that renders the 3D objects using `useRef` and `useFrame`. Directly update the material attributes (`material.emissiveIntensity` or `mesh.scale`) instead of relying on React state to trigger the updates, bypassing the React reconciliation cycle entirely. Also ensure parent canvas wrappers are memoized (`React.memo`).

--- a/components/3d/EscenaMeditacion3D.tsx
+++ b/components/3d/EscenaMeditacion3D.tsx
@@ -14,21 +14,6 @@ interface EscenaMeditacion3DProps {
 
 // ⚡ BOLT: Wrap in React.memo to prevent massive 3D canvas re-renders caused by parent 1-second timers
 export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia, activo, tipoGeometria }: EscenaMeditacion3DProps) {
-  const [intensidad, setIntensidad] = useState(50);
-
-  useEffect(() => {
-    if (!activo) return;
-
-    const intervalo = setInterval(() => {
-      setIntensidad(prev => {
-        const nuevo = prev + (Math.random() - 0.5) * 10;
-        return Math.max(30, Math.min(70, nuevo));
-      });
-    }, 2000);
-
-    return () => clearInterval(intervalo);
-  }, [activo]);
-
   return (
     <div style={{ width: "100%", height: "600px", borderRadius: "20px", overflow: "hidden" }}>
       <Canvas
@@ -55,7 +40,7 @@ export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia,
 
           <GeometriaSagrada3D
             frecuencia={frecuencia}
-            intensidad={intensidad}
+            activo={activo}
             tipo={tipoGeometria}
           />
 

--- a/components/3d/GeometriaSagrada3D.tsx
+++ b/components/3d/GeometriaSagrada3D.tsx
@@ -6,13 +6,15 @@ import * as THREE from "three";
 
 interface GeometriaSagrada3DProps {
   frecuencia: number;
-  intensidad: number;
+  activo: boolean;
   tipo: "flor-vida" | "merkaba" | "metatron" | "torus";
 }
 
-export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSagrada3DProps) {
+export function GeometriaSagrada3D({ frecuencia, activo, tipo }: GeometriaSagrada3DProps) {
   const grupoRef = useRef<THREE.Group>(null);
   const tiempo = useRef(0);
+  const intensidadRef = useRef(50);
+  const lastUpdateRef = useRef(0);
 
   // ⚡ OPTIMIZACIÓN: Calcular color basado en frecuencia solo cuando cambia
   const colorFrecuencia = useMemo(() => {
@@ -64,18 +66,27 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
   useEffect(() => {
     material.color.set(colorFrecuencia);
     material.emissive.set(colorFrecuencia);
-    material.emissiveIntensity = intensidad / 100;
-  }, [material, colorFrecuencia, intensidad]);
+    material.emissiveIntensity = intensidadRef.current / 100;
+  }, [material, colorFrecuencia]);
 
   useEffect(() => {
     return () => material.dispose();
   }, [material]);
 
   // Animación continua
-  useFrame((_state, delta) => {
+  useFrame((state, delta) => {
     if (!grupoRef.current) return;
 
     tiempo.current += delta;
+
+    // ⚡ BOLT: Internalize 2-second intensity update logic to avoid parent component React re-renders
+    if (activo && state.clock.elapsedTime - lastUpdateRef.current >= 2) {
+      const prev = intensidadRef.current;
+      const nuevo = prev + (Math.random() - 0.5) * 10;
+      intensidadRef.current = Math.max(30, Math.min(70, nuevo));
+      lastUpdateRef.current = state.clock.elapsedTime;
+      material.emissiveIntensity = intensidadRef.current / 100;
+    }
 
     // Rotación suave basada en la frecuencia
     const velocidad = frecuencia / 10000;
@@ -83,7 +94,7 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
     grupoRef.current.rotation.x = Math.sin(tiempo.current * 0.3) * 0.2;
 
     // Pulsación basada en intensidad
-    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidad / 200);
+    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidadRef.current / 200);
     grupoRef.current.scale.setScalar(escala);
   });
 


### PR DESCRIPTION
💡 **What**: Refactored `EscenaMeditacion3D` and `GeometriaSagrada3D` to remove the React `useState` and `setInterval` logic that was managing the pulsating 3D intensity. The logic was internalized into `GeometriaSagrada3D` using `useRef` and `useFrame` directly updating Three.js material properties without triggering React updates.

🎯 **Why**: Using React state and `setInterval` in a parent component for high-frequency 3D animations forces the entire 3D Canvas component tree to re-render, leading to performance bottlenecks, dropped frames, and excessive garbage collection.

📊 **Impact**: Reduces parent component re-renders from once every 2 seconds to zero after initial load, significantly offloading the main thread and making the 3D scene more performant. Memory usage and JS execution time during meditation will decrease.

🔬 **Measurement**: Verified the application passes tests and linting. Profiling React will show zero re-renders of the `EscenaMeditacion3D` component while the pulsation effect still happens visually due to native Three.js material updates inside `useFrame`.

---
*PR created automatically by Jules for task [16019764010996159134](https://jules.google.com/task/16019764010996159134) started by @mexicodxnmexico-create*