### PR TITLE
🧪 [Testing] Improve QuantumMirror deviceorientation fractional rounding logic

### DIFF
--- a/tests/quantum-mirror.test.tsx
+++ b/tests/quantum-mirror.test.tsx
@@ -139,6 +139,55 @@ test('QuantumMirror deviceorientation logic', async (t) => {
     });
   });
 
+  await t.test('rounds fractional beta values correctly', () => {
+    let root: TestRenderer.ReactTestRenderer | undefined;
+
+    TestRenderer.act(() => {
+      root = TestRenderer.create(<QuantumMirror />);
+    });
+
+    // Test rounding down (e.g. 44.4 / 10 = 4.44 -> rounds to 4)
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 10, beta: 44.4, gamma: 10 });
+        });
+      }
+    });
+
+    const freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+    let alphaDiv = root!.root.findByProps({ 'data-testid': 'rotation-alpha' });
+    let betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
+    let gammaDiv = root!.root.findByProps({ 'data-testid': 'rotation-gamma' });
+
+    // 432 + Math.round(44.4 / 10) = 432 + 4 = 436
+    assert.strictEqual(freqDiv.children[0], '436');
+    assert.strictEqual(alphaDiv.children[0], '10');
+    assert.strictEqual(betaDiv.children[0], '44.4');
+    assert.strictEqual(gammaDiv.children[0], '10');
+
+    // Test rounding up (e.g. 45.6 / 10 = 4.56 -> rounds to 5)
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 20, beta: 45.6, gamma: 20 });
+        });
+      }
+    });
+
+    // 432 + Math.round(45.6 / 10) = 432 + 5 = 437
+    assert.strictEqual(freqDiv.children[0], '437');
+    assert.strictEqual(alphaDiv.children[0], '20');
+    assert.strictEqual(betaDiv.children[0], '45.6');
+    assert.strictEqual(gammaDiv.children[0], '20');
+
+    TestRenderer.act(() => {
+      root!.unmount();
+    });
+  });
+
   await t.test('handles missing event values gracefully', () => {
     let root: TestRenderer.ReactTestRenderer | undefined;
 


### PR DESCRIPTION
🎯 **What:** The testing gap in `QuantumMirror.tsx` where fractional `beta` values in the `deviceorientation` event were not explicitly tested for proper rounding in the frequency calculation logic (`Math.round(e.beta / 10)`).

📊 **Coverage:** The test suite now explicitly covers rounding edge cases, proving that the frequency calculation rounds up and down correctly based on the `e.beta` value.

✨ **Result:** Test coverage for `src/components/QuantumMirror.tsx` branch coverage logic ensures that decimal variations output from the `deviceorientation` event are handled as designed.

---
*PR created automatically by Jules for task [5065963312020306391](https://jules.google.com/task/5065963312020306391) started by @mexicodxnmexico-create*