### PR TITLE
⚡ Bolt: Internalize 3D animation state to bypass React reconciliation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,8 +27,22 @@ const H1_STYLE: CSSProperties = { fontSize: "3.5rem", marginBottom: "1rem", lett
 const STATUS_STYLE: CSSProperties = { fontSize: "1.25rem", color: "#666", maxWidth: "600px", margin: "0 auto" };
 const FOOTER_STYLE: CSSProperties = { padding: "4rem 0", textAlign: "center", borderTop: "1px solid #eaeaea", color: "#555", fontSize: "0.8rem" };
 const TABS_STYLE: CSSProperties = { display: "flex", justifyContent: "center", gap: "1rem", marginBottom: "2rem" };
-const TAB_BUTTON_STYLE: CSSProperties = { padding: "0.5rem 1rem", border: "1px solid #ccc", borderRadius: "4px", background: "none", cursor: "pointer", fontSize: "1rem" };
-const TAB_BUTTON_ACTIVE_STYLE: CSSProperties = { ...TAB_BUTTON_STYLE, background: "#000", color: "#fff", borderColor: "#000" };
+const TAB_BUTTON_STYLE: CSSProperties = {
+  padding: "0.5rem 1rem",
+  borderWidth: "1px",
+  borderStyle: "solid",
+  borderColor: "#ccc",
+  borderRadius: "4px",
+  background: "none",
+  cursor: "pointer",
+  fontSize: "1rem"
+};
+const TAB_BUTTON_ACTIVE_STYLE: CSSProperties = {
+  ...TAB_BUTTON_STYLE,
+  background: "#000",
+  color: "#fff",
+  borderColor: "#000"
+};
 
 export default function Home() {
   const { state, loading, dispatch } = useQuantum();

--- a/components/3d/EscenaMeditacion3D.tsx
+++ b/components/3d/EscenaMeditacion3D.tsx
@@ -14,21 +14,6 @@ interface EscenaMeditacion3DProps {
 
 // ⚡ BOLT: Wrap in React.memo to prevent massive 3D canvas re-renders caused by parent 1-second timers
 export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia, activo, tipoGeometria }: EscenaMeditacion3DProps) {
-  const [intensidad, setIntensidad] = useState(50);
-
-  useEffect(() => {
-    if (!activo) return;
-
-    const intervalo = setInterval(() => {
-      setIntensidad(prev => {
-        const nuevo = prev + (Math.random() - 0.5) * 10;
-        return Math.max(30, Math.min(70, nuevo));
-      });
-    }, 2000);
-
-    return () => clearInterval(intervalo);
-  }, [activo]);
-
   return (
     <div style={{ width: "100%", height: "600px", borderRadius: "20px", overflow: "hidden" }}>
       <Canvas
@@ -55,8 +40,9 @@ export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia,
 
           <GeometriaSagrada3D
             frecuencia={frecuencia}
-            intensidad={intensidad}
+            intensidad={50}
             tipo={tipoGeometria}
+            activo={activo}
           />
 
           <ParticulasCuanticas

--- a/components/3d/GeometriaSagrada3D.tsx
+++ b/components/3d/GeometriaSagrada3D.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useMemo, useEffect } from "react";
+import { useRef, useMemo, useEffect, memo } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
@@ -8,11 +8,17 @@ interface GeometriaSagrada3DProps {
   frecuencia: number;
   intensidad: number;
   tipo: "flor-vida" | "merkaba" | "metatron" | "torus";
+  activo: boolean;
 }
 
-export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSagrada3DProps) {
+export const GeometriaSagrada3D = memo(function GeometriaSagrada3D({ frecuencia, intensidad, tipo, activo }: GeometriaSagrada3DProps) {
   const grupoRef = useRef<THREE.Group>(null);
   const tiempo = useRef(0);
+
+  // ⚡ BOLT: Internalize intensity state to bypass React re-renders.
+  // We use the initial intensity from props but then manage it internally.
+  const intensidadRef = useRef(intensidad);
+  const ultimoCambioIntensidad = useRef(0);
 
   // ⚡ OPTIMIZACIÓN: Calcular color basado en frecuencia solo cuando cambia
   const colorFrecuencia = useMemo(() => {
@@ -72,18 +78,27 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
   }, [material]);
 
   // Animación continua
-  useFrame((_state, delta) => {
+  useFrame((state, delta) => {
     if (!grupoRef.current) return;
 
     tiempo.current += delta;
+
+    // ⚡ BOLT: Update intensity every 2 seconds without triggering React re-render.
+    if (activo && state.clock.elapsedTime - ultimoCambioIntensidad.current > 2) {
+      intensidadRef.current = Math.max(30, Math.min(70, intensidadRef.current + (Math.random() - 0.5) * 10));
+      ultimoCambioIntensidad.current = state.clock.elapsedTime;
+    }
 
     // Rotación suave basada en la frecuencia
     const velocidad = frecuencia / 10000;
     grupoRef.current.rotation.y += velocidad;
     grupoRef.current.rotation.x = Math.sin(tiempo.current * 0.3) * 0.2;
 
+    // ⚡ BOLT: Update material and scale directly to bypass reconciliation.
+    material.emissiveIntensity = intensidadRef.current / 100;
+
     // Pulsación basada en intensidad
-    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidad / 200);
+    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidadRef.current / 200);
     grupoRef.current.scale.setScalar(escala);
   });
 
@@ -94,7 +109,7 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
       ))}
     </group>
   );
-}
+});
 
 interface GeoData {
   geometria: THREE.BufferGeometry;

--- a/components/3d/ParticulasCuanticas.tsx
+++ b/components/3d/ParticulasCuanticas.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useMemo } from "react";
+import { useRef, useMemo, memo } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
@@ -19,7 +19,7 @@ const COLORES_SOLFEGGIO: Record<number, { r: number; g: number; b: number }> = {
   852: { r: 0.51, g: 0.22, b: 0.93 }
 };
 
-export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuanticasProps) {
+export const ParticulasCuanticas = memo(function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuanticasProps) {
   const particulasRef = useRef<THREE.Points>(null);
   const tiempo = useRef(0);
 
@@ -128,4 +128,4 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
       />
     </points>
   );
-}
+});


### PR DESCRIPTION
💡 What: Internalized the 'intensidad' animation state within the `GeometriaSagrada3D` component using `useRef` and the `useFrame` loop. Added `React.memo` to key 3D components.

🎯 Why: Previously, updating 'intensidad' every 2 seconds via `setInterval` in the parent component (`EscenaMeditacion3D`) triggered a full React re-render of the entire 3D scene (including the `Canvas` and all its children like `Stars` and `ParticulasCuanticas`).

📊 Impact: Significantly reduces CPU usage during meditation by eliminating React reconciliation overhead for the 3D scene every 2 seconds. Animation updates are now performed directly on Three.js objects within the high-performance `useFrame` loop.

🔬 Measurement: Verified that the 3D scene remains stable and animations (pulsing and emissive intensity) function correctly via internal ref-based timing logic. All unit tests passed.

---
*PR created automatically by Jules for task [12008081941472341261](https://jules.google.com/task/12008081941472341261) started by @mexicodxnmexico-create*