### PR TITLE
⚡ Bolt: Internalize 3D animation state and optimize allocations

### DIFF
--- a/components/3d/EscenaMeditacion3D.tsx
+++ b/components/3d/EscenaMeditacion3D.tsx
@@ -2,7 +2,7 @@
 
 import { Canvas } from "@react-three/fiber";
 import { OrbitControls, Stars, Environment } from "@react-three/drei";
-import { Suspense, useState, useEffect, memo } from "react";
+import { Suspense, memo } from "react";
 import { GeometriaSagrada3D } from "./GeometriaSagrada3D";
 import { ParticulasCuanticas } from "./ParticulasCuanticas";
 
@@ -14,21 +14,6 @@ interface EscenaMeditacion3DProps {
 
 // ⚡ BOLT: Wrap in React.memo to prevent massive 3D canvas re-renders caused by parent 1-second timers
 export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia, activo, tipoGeometria }: EscenaMeditacion3DProps) {
-  const [intensidad, setIntensidad] = useState(50);
-
-  useEffect(() => {
-    if (!activo) return;
-
-    const intervalo = setInterval(() => {
-      setIntensidad(prev => {
-        const nuevo = prev + (Math.random() - 0.5) * 10;
-        return Math.max(30, Math.min(70, nuevo));
-      });
-    }, 2000);
-
-    return () => clearInterval(intervalo);
-  }, [activo]);
-
   return (
     <div style={{ width: "100%", height: "600px", borderRadius: "20px", overflow: "hidden" }}>
       <Canvas
@@ -55,7 +40,7 @@ export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia,
 
           <GeometriaSagrada3D
             frecuencia={frecuencia}
-            intensidad={intensidad}
+            activo={activo}
             tipo={tipoGeometria}
           />
 

--- a/components/3d/GeometriaSagrada3D.tsx
+++ b/components/3d/GeometriaSagrada3D.tsx
@@ -1,18 +1,22 @@
 "use client";
 
-import { useRef, useMemo, useEffect } from "react";
+import { useRef, useMemo, useEffect, memo } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
 interface GeometriaSagrada3DProps {
   frecuencia: number;
-  intensidad: number;
+  activo: boolean;
   tipo: "flor-vida" | "merkaba" | "metatron" | "torus";
 }
 
-export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSagrada3DProps) {
+// ⚡ BOLT: Wrap in React.memo to prevent parent re-renders from triggering
+// unnecessary React reconciliation of the 3D scene.
+export const GeometriaSagrada3D = memo(function GeometriaSagrada3D({ frecuencia, activo, tipo }: GeometriaSagrada3DProps) {
   const grupoRef = useRef<THREE.Group>(null);
   const tiempo = useRef(0);
+  const intensidad = useRef(50);
+  const lastIntensidadUpdate = useRef(0);
 
   // ⚡ OPTIMIZACIÓN: Calcular color basado en frecuencia solo cuando cambia
   const colorFrecuencia = useMemo(() => {
@@ -64,18 +68,28 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
   useEffect(() => {
     material.color.set(colorFrecuencia);
     material.emissive.set(colorFrecuencia);
-    material.emissiveIntensity = intensidad / 100;
-  }, [material, colorFrecuencia, intensidad]);
+    // ⚡ BOLT: Emissive intensity is now updated in useFrame to bypass React renders.
+  }, [material, colorFrecuencia]);
 
   useEffect(() => {
     return () => material.dispose();
   }, [material]);
 
   // Animación continua
-  useFrame((_state, delta) => {
+  useFrame((state, delta) => {
     if (!grupoRef.current) return;
 
     tiempo.current += delta;
+
+    // ⚡ BOLT: Internalized intensity fluctuation to bypass React re-renders.
+    // Logic previously resided in the parent EscenaMeditacion3D with a 2s interval.
+    if (activo) {
+      const elapsed = state.clock.elapsedTime;
+      if (elapsed - lastIntensidadUpdate.current > 2) {
+        intensidad.current = Math.max(30, Math.min(70, intensidad.current + (Math.random() - 0.5) * 10));
+        lastIntensidadUpdate.current = elapsed;
+      }
+    }
 
     // Rotación suave basada en la frecuencia
     const velocidad = frecuencia / 10000;
@@ -83,7 +97,9 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
     grupoRef.current.rotation.x = Math.sin(tiempo.current * 0.3) * 0.2;
 
     // Pulsación basada en intensidad
-    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidad / 200);
+    // ⚡ BOLT: Apply intensity directly to material and scale to avoid React scheduling.
+    material.emissiveIntensity = intensidad.current / 100;
+    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidad.current / 200);
     grupoRef.current.scale.setScalar(escala);
   });
 
@@ -94,7 +110,14 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
       ))}
     </group>
   );
-}
+});
+
+GeometriaSagrada3D.displayName = "GeometriaSagrada3D";
+
+// ⚡ BOLT: Module-level scratch objects to avoid per-frame/per-loop allocations.
+const _v1 = new THREE.Vector3();
+const _v2 = new THREE.Vector3();
+const _v3 = new THREE.Vector3();
 
 interface GeoData {
   geometria: THREE.BufferGeometry;
@@ -190,13 +213,14 @@ function crearCuboMetatron(): GeoData[] {
   const cylinderGeo = new THREE.CylinderGeometry(0.03, 0.03, 2, 8);
 
   conexiones.forEach(([i, j]) => {
-    const inicio = new THREE.Vector3(...vertices[i]);
-    const fin = new THREE.Vector3(...vertices[j]);
-    const direccion = new THREE.Vector3().subVectors(fin, inicio);
+    // ⚡ BOLT: Using scratch vectors to avoid allocations within the loop.
+    const v_start = _v1.fromArray(vertices[i]);
+    const v_end = _v2.fromArray(vertices[j]);
+    const v_dir = _v3.subVectors(v_end, v_start);
 
     geometrias.push({
       geometria: cylinderGeo,
-      posicion: inicio.clone().add(direccion.multiplyScalar(0.5))
+      posicion: v_start.clone().add(v_dir.multiplyScalar(0.5))
     });
   });
 

--- a/components/3d/ParticulasCuanticas.tsx
+++ b/components/3d/ParticulasCuanticas.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useMemo } from "react";
+import { useRef, useMemo, memo } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
@@ -19,7 +19,9 @@ const COLORES_SOLFEGGIO: Record<number, { r: number; g: number; b: number }> = {
   852: { r: 0.51, g: 0.22, b: 0.93 }
 };
 
-export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuanticasProps) {
+// ⚡ BOLT: Wrap in React.memo to prevent parent re-renders (like 1-second timers)
+// from triggering unnecessary React reconciliation of the 3D scene.
+export const ParticulasCuanticas = memo(function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuanticasProps) {
   const particulasRef = useRef<THREE.Points>(null);
   const tiempo = useRef(0);
 
@@ -128,4 +130,6 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
       />
     </points>
   );
-}
+});
+
+ParticulasCuanticas.displayName = "ParticulasCuanticas";


### PR DESCRIPTION
💡 What: Optimized React Three Fiber (R3F) rendering by internalizing high-frequency animation state and reducing object allocations.

🎯 Why: The previous implementation used a 2-second \`setInterval\` with React state (\`useState\`) in the parent component (\`EscenaMeditacion3D\`). This triggered full React reconciliation of the entire 3D scene every 2 seconds. Additionally, geometry generation functions were creating new \`THREE.Vector3\` instances in loops, increasing garbage collection (GC) pressure.

📊 Impact: 
- Eliminates React reconciliation for the 3D scene during meditation, reducing main-thread blockage.
- Significant reduction in heap allocations (GC pressure) during geometry generation by using module-level scratch objects.
- Improves frame rate stability and power efficiency by updating Three.js properties directly in the frame loop.

🔬 Measurement: 
- Observe React DevTools; the 3D components no longer re-render when intensity changes.
- Use Chrome DevTools Memory tab; heap allocation rate should decrease when switching between different geometry types.
- Visual verification confirms identical animation behavior.

---
*PR created automatically by Jules for task [11521561038796906436](https://jules.google.com/task/11521561038796906436) started by @mexicodxnmexico-create*