### PR TITLE
⚡ Bolt: Optimize R3F animation loop to eliminate periodic re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,7 @@
 ## 2025-06-24 - Efficient Fixed-Size Array Updates
 **Learning:** Using `[...arr, item].slice(-N)` for maintaining a fixed-size buffer causes two array allocations (one for the spread and one for the final slice). While `shift()` is O(n), using `slice()` followed by `push()` and `shift()` is significantly faster because it minimizes heap pressure by avoiding the intermediate array allocation.
 **Action:** Prefer `slice()` + `push()` + `shift()` for more efficient memory management in state transitions.
+
+## 2025-07-01 - R3F useFrame instead of setInterval State Updates
+**Learning:** Found that `EscenaMeditacion3D` was using `setInterval` to update a React state (`intensidad`) every 2 seconds. This caused the entire Canvas to be re-rendered periodically by the React Reconciler, which is a massive performance killer in React Three Fiber apps.
+**Action:** Move rapidly changing values into `useRef` inside the inner 3D component (`GeometriaSagrada3D`) and calculate updates entirely within the `useFrame` loop using `_state.clock.elapsedTime` for throttling. Update `material` and `mesh` properties directly. This provides a 100% reduction in React re-renders for the 3D scene while maintaining the exact visual effect.

--- a/components/3d/EscenaMeditacion3D.tsx
+++ b/components/3d/EscenaMeditacion3D.tsx
@@ -2,7 +2,7 @@
 
 import { Canvas } from "@react-three/fiber";
 import { OrbitControls, Stars, Environment } from "@react-three/drei";
-import { Suspense, useState, useEffect, memo } from "react";
+import { Suspense, memo } from "react";
 import { GeometriaSagrada3D } from "./GeometriaSagrada3D";
 import { ParticulasCuanticas } from "./ParticulasCuanticas";
 
@@ -14,21 +14,6 @@ interface EscenaMeditacion3DProps {
 
 // ⚡ BOLT: Wrap in React.memo to prevent massive 3D canvas re-renders caused by parent 1-second timers
 export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia, activo, tipoGeometria }: EscenaMeditacion3DProps) {
-  const [intensidad, setIntensidad] = useState(50);
-
-  useEffect(() => {
-    if (!activo) return;
-
-    const intervalo = setInterval(() => {
-      setIntensidad(prev => {
-        const nuevo = prev + (Math.random() - 0.5) * 10;
-        return Math.max(30, Math.min(70, nuevo));
-      });
-    }, 2000);
-
-    return () => clearInterval(intervalo);
-  }, [activo]);
-
   return (
     <div style={{ width: "100%", height: "600px", borderRadius: "20px", overflow: "hidden" }}>
       <Canvas
@@ -55,7 +40,7 @@ export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia,
 
           <GeometriaSagrada3D
             frecuencia={frecuencia}
-            intensidad={intensidad}
+            activo={activo}
             tipo={tipoGeometria}
           />
 

--- a/components/3d/GeometriaSagrada3D.tsx
+++ b/components/3d/GeometriaSagrada3D.tsx
@@ -6,13 +6,15 @@ import * as THREE from "three";
 
 interface GeometriaSagrada3DProps {
   frecuencia: number;
-  intensidad: number;
+  activo: boolean;
   tipo: "flor-vida" | "merkaba" | "metatron" | "torus";
 }
 
-export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSagrada3DProps) {
+export function GeometriaSagrada3D({ frecuencia, activo, tipo }: GeometriaSagrada3DProps) {
   const grupoRef = useRef<THREE.Group>(null);
   const tiempo = useRef(0);
+  const intensidad = useRef(50);
+  const ultimoActualizacionIntensidad = useRef(0);
 
   // ⚡ OPTIMIZACIÓN: Calcular color basado en frecuencia solo cuando cambia
   const colorFrecuencia = useMemo(() => {
@@ -64,8 +66,8 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
   useEffect(() => {
     material.color.set(colorFrecuencia);
     material.emissive.set(colorFrecuencia);
-    material.emissiveIntensity = intensidad / 100;
-  }, [material, colorFrecuencia, intensidad]);
+    // emissiveIntensity is now updated in useFrame to avoid re-renders
+  }, [material, colorFrecuencia]);
 
   useEffect(() => {
     return () => material.dispose();
@@ -82,8 +84,18 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
     grupoRef.current.rotation.y += velocidad;
     grupoRef.current.rotation.x = Math.sin(tiempo.current * 0.3) * 0.2;
 
+    // ⚡ BOLT: Calculate and apply intensity entirely within the frame loop
+    // This avoids periodic React state updates and component re-renders
+    if (activo && _state.clock.elapsedTime - ultimoActualizacionIntensidad.current > 2) {
+      const nuevo = intensidad.current + (Math.random() - 0.5) * 10;
+      intensidad.current = Math.max(30, Math.min(70, nuevo));
+      ultimoActualizacionIntensidad.current = _state.clock.elapsedTime;
+    }
+
+    material.emissiveIntensity = intensidad.current / 100;
+
     // Pulsación basada en intensidad
-    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidad / 200);
+    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidad.current / 200);
     grupoRef.current.scale.setScalar(escala);
   });
 


### PR DESCRIPTION
💡 **What**:
Moved the `intensidad` calculation from a 2-second `setInterval` with React state (`useState`) in `EscenaMeditacion3D.tsx` directly into the `useFrame` loop in `GeometriaSagrada3D.tsx` using `useRef`.

🎯 **Why**:
Updating React state in a parent component of a React Three Fiber `Canvas` forces the React Reconciler to run and re-render the 3D scene periodically. This is highly inefficient. By internalizing the state using refs and updating the Three.js material properties directly within `useFrame` (throttled using `state.clock.elapsedTime`), we bypass React completely.

📊 **Impact**:
100% reduction in periodic React re-renders triggered by the `EscenaMeditacion3D` timer while the meditation scene is active.

🔬 **Measurement**:
Run the app, start the 3D meditation, and observe the React Profiler. There will no longer be regular commits occurring every 2 seconds, while the geometry continues to visibly pulsate randomly as intended. Tests confirm no regressions.

---
*PR created automatically by Jules for task [9176102548214157271](https://jules.google.com/task/9176102548214157271) started by @mexicodxnmexico-create*