### PR TITLE
🧪 [testing improvement] Add fractional rounding tests for QuantumMirror deviceorientation logic

### DIFF
--- a/tests/quantum-mirror.test.tsx
+++ b/tests/quantum-mirror.test.tsx
@@ -139,6 +139,49 @@ test('QuantumMirror deviceorientation logic', async (t) => {
     });
   });
 
+  await t.test('handles fractional beta values correctly with Math.round', () => {
+    let root: TestRenderer.ReactTestRenderer | undefined;
+
+    TestRenderer.act(() => {
+      root = TestRenderer.create(<QuantumMirror />);
+    });
+
+    // Test rounding down (4.49 -> 4)
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 10, beta: 44.9, gamma: 10 });
+        });
+      }
+    });
+
+    const freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+    const betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
+
+    // 432 + Math.round(44.9 / 10) = 432 + Math.round(4.49) = 432 + 4 = 436
+    assert.strictEqual(freqDiv.children[0], '436');
+    assert.strictEqual(betaDiv.children[0], '44.9');
+
+    // Test rounding up (4.51 -> 5)
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 10, beta: 45.1, gamma: 10 });
+        });
+      }
+    });
+
+    // 432 + Math.round(45.1 / 10) = 432 + Math.round(4.51) = 432 + 5 = 437
+    assert.strictEqual(freqDiv.children[0], '437');
+    assert.strictEqual(betaDiv.children[0], '45.1');
+
+    TestRenderer.act(() => {
+      root!.unmount();
+    });
+  });
+
   await t.test('handles missing event values gracefully', () => {
     let root: TestRenderer.ReactTestRenderer | undefined;
 


### PR DESCRIPTION
🎯 **What:** The `QuantumMirror` component relies on `Math.round(e.beta / 10)` to calculate its `frequency` from the `deviceorientation` event's `beta` value. While basic values were tested, there were no explicit checks verifying that fractional values trigger correct rounding up and down. This PR adds explicit tests for fractional values.

📊 **Coverage:** A new test case `handles fractional beta values correctly with Math.round` was added, simulating `deviceorientation` events with beta values of `44.9` and `45.1` to confirm they round to `4` and `5`, and appropriately increment the base frequency (`432`) to `436` and `437`.

✨ **Result:** Enhanced test coverage provides confidence that the rounding logic works as expected. Testing gaps relating to device orientation event's fractional inputs have been closed. Tested using `npx tsx --test tests/quantum-mirror.test.tsx`, all 6 specific tests pass. Overall test suite remains healthy and passes 100%.

---
*PR created automatically by Jules for task [13588721274830443966](https://jules.google.com/task/13588721274830443966) started by @mexicodxnmexico-create*