### PR TITLE
🎨 Palette: Add skip button to multi-step onboarding

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-03-15 - Critical Error State Accessibility
 **Learning:** When a system enters a critical error or collapsed state that disables primary UI interactions, simply rendering the state is insufficient. It requires 'role="alert"' to announce the critical state and explicit focus shifting (via 'autoFocus' or 'useEffect' with 'useRef') to the primary recovery action to maintain accessibility.
 **Action:** Always add 'role="alert"' to error containers and explicitly shift focus to the recovery button or primary text when a disruptive error state mounts.
+
+## 2024-04-08 - Added "Skip" button to multi-step onboarding
+**Learning:** The multi-step modal (`components/Onboarding.tsx`) forced users to click "Siguiente" multiple times before allowing interaction with the main app. This creates friction for returning users whose `localStorage` state was cleared, or for power users who want to explore the interface immediately.
+**Action:** When implementing multi-step tutorials or modals, always provide a clear, secondary "Skip" or "Saltar" action alongside the primary "Next" action, ensuring users maintain control over their navigation flow.

--- a/components/Onboarding.tsx
+++ b/components/Onboarding.tsx
@@ -75,25 +75,44 @@ export const Onboarding = memo(function Onboarding({ onComplete }: { onComplete:
           Paso {step + 1} de {steps.length}
         </div>
 
-        <button
-          onClick={() => {
-            if (step === steps.length - 1) {
-              onComplete();
-            }
-            setStep(s => s + 1);
-          }}
-          style={{
-            padding: "0.75rem 2rem",
-            backgroundColor: "#000",
-            color: "#fff",
-            border: "none",
-            borderRadius: "8px",
-            cursor: "pointer",
-            fontWeight: "bold"
-          }}
-        >
-          {step === steps.length - 1 ? "Entrar al Espejo" : "Siguiente"}
-        </button>
+        <div style={{ display: "flex", justifyContent: "center", gap: "1rem" }}>
+          {step < steps.length - 1 && (
+            <button
+              onClick={onComplete}
+              style={{
+                padding: "0.75rem 2rem",
+                backgroundColor: "transparent",
+                color: "#555",
+                border: "1px solid #ccc",
+                borderRadius: "8px",
+                cursor: "pointer",
+                fontWeight: "bold"
+              }}
+            >
+              Saltar
+            </button>
+          )}
+          <button
+            onClick={() => {
+              if (step === steps.length - 1) {
+                onComplete();
+              } else {
+                setStep(s => s + 1);
+              }
+            }}
+            style={{
+              padding: "0.75rem 2rem",
+              backgroundColor: "#000",
+              color: "#fff",
+              border: "none",
+              borderRadius: "8px",
+              cursor: "pointer",
+              fontWeight: "bold"
+            }}
+          >
+            {step === steps.length - 1 ? "Entrar al Espejo" : "Siguiente"}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
💡 **What**: Added a "Saltar" (Skip) button next to the "Siguiente" button in the multi-step `Onboarding` component.
🎯 **Why**: Prevents users from feeling trapped in a multi-step tutorial, allowing returning users with cleared local state or power users to dive straight into the application, reducing friction.
📸 **Before/After**: The modal now features a centered flexbox row with two buttons ("Saltar" styled transparently, "Siguiente" styled solidly) until the final step.
♿ **Accessibility**: The new button uses semantic `<button>` tags, inherits proper focus states, and uses clear "Saltar" text rather than an ambiguous icon.

---
*PR created automatically by Jules for task [7854265575345869070](https://jules.google.com/task/7854265575345869070) started by @mexicodxnmexico-create*