### PR TITLE
⚡ Bolt: Prevent massive 3D canvas re-renders by internalizing intensity logic

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,7 @@
 ## 2025-06-24 - Efficient Fixed-Size Array Updates
 **Learning:** Using `[...arr, item].slice(-N)` for maintaining a fixed-size buffer causes two array allocations (one for the spread and one for the final slice). While `shift()` is O(n), using `slice()` followed by `push()` and `shift()` is significantly faster because it minimizes heap pressure by avoiding the intermediate array allocation.
 **Action:** Prefer `slice()` + `push()` + `shift()` for more efficient memory management in state transitions.
+
+## 2025-06-25 - Internalizing 3D Animation State
+**Learning:** Found that `EscenaMeditacion3D` was using React `useState` and `setInterval` to update a `intensidad` prop every 2 seconds, which was then passed down to `GeometriaSagrada3D`. This caused the entire `<Canvas>` component and its heavy 3D children to reconcile constantly, fighting with the render loop.
+**Action:** Removed React state for continuous animation logic. Passed a static `activo` boolean instead, and internalized the 2-second interval logic directly into the `useFrame` hook using `state.clock.elapsedTime` and a `useRef`. This allows direct mutation of `material.emissiveIntensity`, entirely bypassing React's reconciliation overhead for a significant performance gain.

--- a/components/3d/EscenaMeditacion3D.tsx
+++ b/components/3d/EscenaMeditacion3D.tsx
@@ -2,7 +2,7 @@
 
 import { Canvas } from "@react-three/fiber";
 import { OrbitControls, Stars, Environment } from "@react-three/drei";
-import { Suspense, useState, useEffect, memo } from "react";
+import { Suspense, memo } from "react";
 import { GeometriaSagrada3D } from "./GeometriaSagrada3D";
 import { ParticulasCuanticas } from "./ParticulasCuanticas";
 
@@ -14,21 +14,6 @@ interface EscenaMeditacion3DProps {
 
 // ⚡ BOLT: Wrap in React.memo to prevent massive 3D canvas re-renders caused by parent 1-second timers
 export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia, activo, tipoGeometria }: EscenaMeditacion3DProps) {
-  const [intensidad, setIntensidad] = useState(50);
-
-  useEffect(() => {
-    if (!activo) return;
-
-    const intervalo = setInterval(() => {
-      setIntensidad(prev => {
-        const nuevo = prev + (Math.random() - 0.5) * 10;
-        return Math.max(30, Math.min(70, nuevo));
-      });
-    }, 2000);
-
-    return () => clearInterval(intervalo);
-  }, [activo]);
-
   return (
     <div style={{ width: "100%", height: "600px", borderRadius: "20px", overflow: "hidden" }}>
       <Canvas
@@ -55,7 +40,7 @@ export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia,
 
           <GeometriaSagrada3D
             frecuencia={frecuencia}
-            intensidad={intensidad}
+            activo={activo}
             tipo={tipoGeometria}
           />
 

--- a/components/3d/GeometriaSagrada3D.tsx
+++ b/components/3d/GeometriaSagrada3D.tsx
@@ -6,13 +6,15 @@ import * as THREE from "three";
 
 interface GeometriaSagrada3DProps {
   frecuencia: number;
-  intensidad: number;
+  activo: boolean;
   tipo: "flor-vida" | "merkaba" | "metatron" | "torus";
 }
 
-export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSagrada3DProps) {
+export function GeometriaSagrada3D({ frecuencia, activo, tipo }: GeometriaSagrada3DProps) {
   const grupoRef = useRef<THREE.Group>(null);
   const tiempo = useRef(0);
+  const intensidadRef = useRef(50);
+  const ultimoUpdateRef = useRef(0);
 
   // ⚡ OPTIMIZACIÓN: Calcular color basado en frecuencia solo cuando cambia
   const colorFrecuencia = useMemo(() => {
@@ -64,18 +66,29 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
   useEffect(() => {
     material.color.set(colorFrecuencia);
     material.emissive.set(colorFrecuencia);
-    material.emissiveIntensity = intensidad / 100;
-  }, [material, colorFrecuencia, intensidad]);
+    // ⚡ BOLT: Initial emissive intensity setting; further updates happen in useFrame
+    material.emissiveIntensity = intensidadRef.current / 100;
+  }, [material, colorFrecuencia]);
 
   useEffect(() => {
     return () => material.dispose();
   }, [material]);
 
   // Animación continua
-  useFrame((_state, delta) => {
+  useFrame((state, delta) => {
     if (!grupoRef.current) return;
 
     tiempo.current += delta;
+
+    // ⚡ BOLT OPTIMIZATION: Internalize intensity calculation to avoid React re-renders.
+    // Update target value every 2 seconds without triggering component reconciliation.
+    if (activo && state.clock.elapsedTime - ultimoUpdateRef.current > 2) {
+      ultimoUpdateRef.current = state.clock.elapsedTime;
+      const nuevo = intensidadRef.current + (Math.random() - 0.5) * 10;
+      intensidadRef.current = Math.max(30, Math.min(70, nuevo));
+      // Update material properties directly
+      material.emissiveIntensity = intensidadRef.current / 100;
+    }
 
     // Rotación suave basada en la frecuencia
     const velocidad = frecuencia / 10000;
@@ -83,7 +96,7 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
     grupoRef.current.rotation.x = Math.sin(tiempo.current * 0.3) * 0.2;
 
     // Pulsación basada en intensidad
-    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidad / 200);
+    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidadRef.current / 200);
     grupoRef.current.scale.setScalar(escala);
   });
 


### PR DESCRIPTION
💡 **What:** 
Removed `useState` and `setInterval` from the parent `EscenaMeditacion3D` component that was updating an `intensidad` prop every 2 seconds. Instead, passed an `activo` boolean and internalized the 2-second timing logic inside `GeometriaSagrada3D` using `useRef` and `state.clock.elapsedTime` within the `useFrame` loop.

🎯 **Why:** 
Driving continuous 3D WebGL animations with React state is a major performance anti-pattern. Every time the interval fired, it triggered a full React component tree reconciliation for the heavy `<Canvas>` elements. By moving the logic into the `useFrame` hook, we bypass React entirely and update the Three.js material properties directly in the render loop.

📊 **Impact:** 
Eliminates all unnecessary React re-renders of the 3D scene that were occurring every 2 seconds, drastically reducing CPU usage and garbage collection overhead during the meditation session.

🔬 **Measurement:** 
1. Open React DevTools Profiler while the 3D meditation is active.
2. Observe that `EscenaMeditacion3D` and its children no longer re-render every 2 seconds.
3. The visual pulsing effect (emissive intensity changing every 2s) remains perfectly smooth and mathematically identical.

---
*PR created automatically by Jules for task [9591628369203527407](https://jules.google.com/task/9591628369203527407) started by @mexicodxnmexico-create*