### PR TITLE
🎨 Palette: Add screen reader announcements for personal insights

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-03-15 - Critical Error State Accessibility
 **Learning:** When a system enters a critical error or collapsed state that disables primary UI interactions, simply rendering the state is insufficient. It requires 'role="alert"' to announce the critical state and explicit focus shifting (via 'autoFocus' or 'useEffect' with 'useRef') to the primary recovery action to maintain accessibility.
 **Action:** Always add 'role="alert"' to error containers and explicitly shift focus to the recovery button or primary text when a disruptive error state mounts.
+
+## 2024-05-24 - Dynamic Insight Accessibility
+**Learning:** Dynamic text regions that update without page reloads (like reflection count insights) need explicit 'role="status"' and 'aria-live="polite"' to ensure screen readers announce the changes seamlessly as they happen.
+**Action:** Always add 'role="status"' and 'aria-live="polite"' to containers with text that updates based on user interaction or state changes.

--- a/components/PersonalInsight.tsx
+++ b/components/PersonalInsight.tsx
@@ -10,7 +10,11 @@ export const PersonalInsight = memo(function PersonalInsight({ reflectionCount }
   else message = "Eres un maestro de la realidad reflejada. El espejo y tú sois uno.";
 
   return (
-    <div style={{ marginTop: "3rem", padding: "1.5rem", borderRadius: "12px", background: "linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)", textAlign: "center" }}>
+    <div
+      role="status"
+      aria-live="polite"
+      style={{ marginTop: "3rem", padding: "1.5rem", borderRadius: "12px", background: "linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)", textAlign: "center" }}
+    >
       <h4 style={{ margin: "0 0 0.5rem 0", textTransform: "uppercase", fontSize: "0.75rem", color: "#666" }}>Insight Personal</h4>
       <p style={{ margin: 0, fontWeight: "500", color: "#333" }}>{message}</p>
     </div>


### PR DESCRIPTION
💡 What: Added `role="status"` and `aria-live="polite"` attributes to the `PersonalInsight` component container.

🎯 Why: The personal insight text dynamically updates as the user's reflection count increases. Without these ARIA attributes, screen reader users would not be notified of these updates, missing key feedback about their progress.

📸 Before/After: N/A (Non-visual change)

♿ Accessibility: Ensures that dynamic textual changes to the personal insight are announced politely by screen readers as they happen.

---
*PR created automatically by Jules for task [15606095896346582232](https://jules.google.com/task/15606095896346582232) started by @mexicodxnmexico-create*