### PR TITLE
🧪 [Add fractional rounding tests for QuantumMirror]

### DIFF
--- a/tests/quantum-mirror.test.tsx
+++ b/tests/quantum-mirror.test.tsx
@@ -139,6 +139,70 @@ test('QuantumMirror deviceorientation logic', async (t) => {
     });
   });
 
+  await t.test('handles fractional beta values correctly (rounding)', () => {
+    let root: TestRenderer.ReactTestRenderer | undefined;
+
+    TestRenderer.act(() => {
+      root = TestRenderer.create(<QuantumMirror />);
+    });
+
+    // Test rounding down: 45.4 / 10 = 4.54 -> rounds to 5
+    // Wait, Math.round(45.4 / 10) = Math.round(4.54) = 5
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 10, beta: 45.4, gamma: -10 });
+        });
+      }
+    });
+
+    let freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+    let betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
+
+    // 432 + Math.round(45.4 / 10) = 432 + 5 = 437
+    assert.strictEqual(freqDiv.children[0], '437');
+    assert.strictEqual(betaDiv.children[0], '45.4');
+
+    // Test rounding down: 44.9 / 10 = 4.49 -> rounds to 4
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 10, beta: 44.9, gamma: -10 });
+        });
+      }
+    });
+
+    freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+    betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
+
+    // 432 + Math.round(44.9 / 10) = 432 + 4 = 436
+    assert.strictEqual(freqDiv.children[0], '436');
+    assert.strictEqual(betaDiv.children[0], '44.9');
+
+    // Test negative rounding: -45.4 / 10 = -4.54 -> rounds to -5
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 10, beta: -45.4, gamma: -10 });
+        });
+      }
+    });
+
+    freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+    betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
+
+    // 432 + Math.round(-45.4 / 10) = 432 - 5 = 427
+    assert.strictEqual(freqDiv.children[0], '427');
+    assert.strictEqual(betaDiv.children[0], '-45.4');
+
+    TestRenderer.act(() => {
+      root!.unmount();
+    });
+  });
+
   await t.test('handles missing event values gracefully', () => {
     let root: TestRenderer.ReactTestRenderer | undefined;
 


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was testing the fractional inputs (e.g. `45.4`) for `beta` values on the `deviceorientation` logic.
📊 **Coverage:** Fractional input scenarios that trigger `Math.round(e.beta / 10)` in `QuantumMirror.tsx` have been added. Coverage now properly encompasses cases rounding up and down, and tests for negative fractional inputs are included.
✨ **Result:** Improved verification for `QuantumMirror.tsx` to ensure `deviceorientation` handles real world cases where floating point device rotational orientation measurements are supplied.

---
*PR created automatically by Jules for task [17429389665485793834](https://jules.google.com/task/17429389665485793834) started by @mexicodxnmexico-create*