### PR TITLE
⚡ Bolt: Internalize R3F animation state to prevent parent re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,7 @@
 ## 2025-06-24 - Efficient Fixed-Size Array Updates
 **Learning:** Using `[...arr, item].slice(-N)` for maintaining a fixed-size buffer causes two array allocations (one for the spread and one for the final slice). While `shift()` is O(n), using `slice()` followed by `push()` and `shift()` is significantly faster because it minimizes heap pressure by avoiding the intermediate array allocation.
 **Action:** Prefer `slice()` + `push()` + `shift()` for more efficient memory management in state transitions.
+
+## 2025-06-25 - Internalizing R3F Animation State
+**Learning:** Found that using React `useState` to drive animations in React Three Fiber (like the pulsing `intensidad` in `EscenaMeditacion3D`) triggers unnecessary React render cycles for the entire 3D canvas and its children, leading to performance degradation.
+**Action:** Internalize high-frequency animation state using `useRef` and perform the periodic updates inside the child component. Then, inside the R3F `useFrame` loop, read from the `useRef` and mutate the Three.js objects directly (e.g., `material.emissiveIntensity = ref.current`) to bypass React reconciliation entirely.

--- a/components/3d/EscenaMeditacion3D.tsx
+++ b/components/3d/EscenaMeditacion3D.tsx
@@ -14,21 +14,6 @@ interface EscenaMeditacion3DProps {
 
 // ⚡ BOLT: Wrap in React.memo to prevent massive 3D canvas re-renders caused by parent 1-second timers
 export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia, activo, tipoGeometria }: EscenaMeditacion3DProps) {
-  const [intensidad, setIntensidad] = useState(50);
-
-  useEffect(() => {
-    if (!activo) return;
-
-    const intervalo = setInterval(() => {
-      setIntensidad(prev => {
-        const nuevo = prev + (Math.random() - 0.5) * 10;
-        return Math.max(30, Math.min(70, nuevo));
-      });
-    }, 2000);
-
-    return () => clearInterval(intervalo);
-  }, [activo]);
-
   return (
     <div style={{ width: "100%", height: "600px", borderRadius: "20px", overflow: "hidden" }}>
       <Canvas
@@ -55,7 +40,7 @@ export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia,
 
           <GeometriaSagrada3D
             frecuencia={frecuencia}
-            intensidad={intensidad}
+            activo={activo}
             tipo={tipoGeometria}
           />
 

--- a/components/3d/GeometriaSagrada3D.tsx
+++ b/components/3d/GeometriaSagrada3D.tsx
@@ -6,13 +6,28 @@ import * as THREE from "three";
 
 interface GeometriaSagrada3DProps {
   frecuencia: number;
-  intensidad: number;
+  activo: boolean;
   tipo: "flor-vida" | "merkaba" | "metatron" | "torus";
 }
 
-export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSagrada3DProps) {
+export function GeometriaSagrada3D({ frecuencia, activo, tipo }: GeometriaSagrada3DProps) {
   const grupoRef = useRef<THREE.Group>(null);
   const tiempo = useRef(0);
+
+  // ⚡ BOLT OPTIMIZATION: Internalize high-frequency animation state to bypass React reconciliation
+  const intensidadRef = useRef(50);
+
+  useEffect(() => {
+    if (!activo) return;
+
+    const intervalo = setInterval(() => {
+      const prev = intensidadRef.current;
+      const nuevo = prev + (Math.random() - 0.5) * 10;
+      intensidadRef.current = Math.max(30, Math.min(70, nuevo));
+    }, 2000);
+
+    return () => clearInterval(intervalo);
+  }, [activo]);
 
   // ⚡ OPTIMIZACIÓN: Calcular color basado en frecuencia solo cuando cambia
   const colorFrecuencia = useMemo(() => {
@@ -64,8 +79,7 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
   useEffect(() => {
     material.color.set(colorFrecuencia);
     material.emissive.set(colorFrecuencia);
-    material.emissiveIntensity = intensidad / 100;
-  }, [material, colorFrecuencia, intensidad]);
+  }, [material, colorFrecuencia]);
 
   useEffect(() => {
     return () => material.dispose();
@@ -83,8 +97,11 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
     grupoRef.current.rotation.x = Math.sin(tiempo.current * 0.3) * 0.2;
 
     // Pulsación basada en intensidad
-    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidad / 200);
+    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidadRef.current / 200);
     grupoRef.current.scale.setScalar(escala);
+
+    // ⚡ BOLT: Update target Three.js properties directly inside the frame loop
+    material.emissiveIntensity = intensidadRef.current / 100;
   });
 
   return (


### PR DESCRIPTION
💡 **What**: Refactored the `intensidad` animation state in the 3D meditation scene. Moved the `useState` and `setInterval` from the parent `EscenaMeditacion3D` to an internalized `useRef` inside the child `GeometriaSagrada3D`. The visual updates are now applied directly to the Three.js material inside the `useFrame` loop.

🎯 **Why**: Using React state (`useState`) to drive frequent animations (every 2 seconds) in a React Three Fiber application triggers unnecessary and expensive React reconciliations across the entire 3D canvas and its children, leading to performance degradation and dropped frames.

📊 **Impact**: Reduces React re-renders of the `EscenaMeditacion3D` component and the entire `Canvas` tree from once every 2 seconds to zero during the meditation session. This significantly improves animation smoothness and reduces CPU overhead.

🔬 **Measurement**: Verify by using React DevTools Profiler while the meditation is active. The parent component `EscenaMeditacion3D` will no longer show re-renders on the timeline, while the 3D geometry will continue to pulse visually.

---
*PR created automatically by Jules for task [10962979910310027793](https://jules.google.com/task/10962979910310027793) started by @mexicodxnmexico-create*