### PR TITLE
🎨 Palette: Form label accessibility improvements

### DIFF
--- a/components/meditacion/MeditacionAudioVisual3D.tsx
+++ b/components/meditacion/MeditacionAudioVisual3D.tsx
@@ -146,10 +146,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="frecuencia" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Frecuencia Solfeggio
-          </h3>
+          </label>
           <select
+            id="frecuencia"
             value={frecuenciaSeleccionada}
             onChange={(e) => setFrecuenciaSeleccionada(Number(e.target.value))}
             disabled={activo}
@@ -176,10 +177,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="geometria" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Geometría Sagrada
-          </h3>
+          </label>
           <select
+            id="geometria"
             value={geometriaSeleccionada}
             onChange={(e) => setGeometriaSeleccionada(e.target.value as any)}
             disabled={activo}
@@ -206,10 +208,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="duracion" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Duración (minutos)
-          </h3>
+          </label>
           <input
+            id="duracion"
             type="number"
             min="1"
             max="60"


### PR DESCRIPTION
## 💡 What
Converted visual `<h3>` headers in the 3D meditation controls panel into semantic `<label>` tags. Added matching `htmlFor` and `id` properties to explicitly link the labels to the Frecuencia, Geometría, and Duración input fields.

## 🎯 Why
Using standard heading tags to label form inputs violates web accessibility standards. By using proper semantic `<label>` elements linked with the `htmlFor` property, we make the interface more accessible, particularly for screen-reader users, and inherently increase the click target size to focus the elements.

## 📸 Before/After
*(Visuals remain identical due to the inline style matching (`display: "block"`, `font-weight: "bold"`), but the DOM structure is now semantically correct)*.

## ♿ Accessibility
This change provides massive improvements for screen-reader functionality, enabling assistive technologies to properly identify the purpose of the adjacent select/input elements.

---
*PR created automatically by Jules for task [9597504005001605554](https://jules.google.com/task/9597504005001605554) started by @mexicodxnmexico-create*