### PR TITLE
⚡ Bolt: Internalize 3D animation state to prevent R3F re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,6 @@
 ## 2025-06-24 - Efficient Fixed-Size Array Updates
 **Learning:** Using `[...arr, item].slice(-N)` for maintaining a fixed-size buffer causes two array allocations (one for the spread and one for the final slice). While `shift()` is O(n), using `slice()` followed by `push()` and `shift()` is significantly faster because it minimizes heap pressure by avoiding the intermediate array allocation.
 **Action:** Prefer `slice()` + `push()` + `shift()` for more efficient memory management in state transitions.
+## 2025-06-25 - Internalizing R3F Animation State
+**Learning:** Found that driving continuous 3D material updates (like emissiveIntensity) using React state (`useState` and `setInterval`) in a parent component causes the entire React Three Fiber canvas to re-render, creating massive overhead for simple animations.
+**Action:** Internalize periodic state changes directly inside the child component's `useFrame` loop using `useRef`. Update the Three.js material properties directly (e.g., `material.emissiveIntensity`) to bypass React's asynchronous effect scheduling entirely.

--- a/components/3d/EscenaMeditacion3D.tsx
+++ b/components/3d/EscenaMeditacion3D.tsx
@@ -2,7 +2,7 @@
 
 import { Canvas } from "@react-three/fiber";
 import { OrbitControls, Stars, Environment } from "@react-three/drei";
-import { Suspense, useState, useEffect, memo } from "react";
+import { Suspense, memo } from "react";
 import { GeometriaSagrada3D } from "./GeometriaSagrada3D";
 import { ParticulasCuanticas } from "./ParticulasCuanticas";
 
@@ -14,21 +14,6 @@ interface EscenaMeditacion3DProps {
 
 // ⚡ BOLT: Wrap in React.memo to prevent massive 3D canvas re-renders caused by parent 1-second timers
 export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia, activo, tipoGeometria }: EscenaMeditacion3DProps) {
-  const [intensidad, setIntensidad] = useState(50);
-
-  useEffect(() => {
-    if (!activo) return;
-
-    const intervalo = setInterval(() => {
-      setIntensidad(prev => {
-        const nuevo = prev + (Math.random() - 0.5) * 10;
-        return Math.max(30, Math.min(70, nuevo));
-      });
-    }, 2000);
-
-    return () => clearInterval(intervalo);
-  }, [activo]);
-
   return (
     <div style={{ width: "100%", height: "600px", borderRadius: "20px", overflow: "hidden" }}>
       <Canvas
@@ -55,7 +40,7 @@ export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia,
 
           <GeometriaSagrada3D
             frecuencia={frecuencia}
-            intensidad={intensidad}
+            activo={activo}
             tipo={tipoGeometria}
           />
 

--- a/components/3d/GeometriaSagrada3D.tsx
+++ b/components/3d/GeometriaSagrada3D.tsx
@@ -6,13 +6,16 @@ import * as THREE from "three";
 
 interface GeometriaSagrada3DProps {
   frecuencia: number;
-  intensidad: number;
+  activo: boolean;
   tipo: "flor-vida" | "merkaba" | "metatron" | "torus";
 }
 
-export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSagrada3DProps) {
+export function GeometriaSagrada3D({ frecuencia, activo, tipo }: GeometriaSagrada3DProps) {
   const grupoRef = useRef<THREE.Group>(null);
   const tiempo = useRef(0);
+  const targetIntensidadRef = useRef(50);
+  const intensidadActualRef = useRef(50);
+  const ultimoUpdateIntensidad = useRef(0);
 
   // ⚡ OPTIMIZACIÓN: Calcular color basado en frecuencia solo cuando cambia
   const colorFrecuencia = useMemo(() => {
@@ -64,8 +67,7 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
   useEffect(() => {
     material.color.set(colorFrecuencia);
     material.emissive.set(colorFrecuencia);
-    material.emissiveIntensity = intensidad / 100;
-  }, [material, colorFrecuencia, intensidad]);
+  }, [material, colorFrecuencia]);
 
   useEffect(() => {
     return () => material.dispose();
@@ -77,13 +79,33 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
 
     tiempo.current += delta;
 
+    // ⚡ BOLT OPTIMIZATION: Internalize periodic intensity changes inside useFrame
+    // to prevent parent re-renders. Smooth interpolation over time.
+    if (activo) {
+      if (tiempo.current - ultimoUpdateIntensidad.current > 2) {
+        ultimoUpdateIntensidad.current = tiempo.current;
+        const nuevoTarget = targetIntensidadRef.current + (Math.random() - 0.5) * 10;
+        targetIntensidadRef.current = Math.max(30, Math.min(70, nuevoTarget));
+      }
+
+      // Smoothly interpolate current intensity towards target
+      intensidadActualRef.current += (targetIntensidadRef.current - intensidadActualRef.current) * delta;
+    } else {
+      // Reset intensity when not active
+      intensidadActualRef.current += (50 - intensidadActualRef.current) * delta;
+      targetIntensidadRef.current = 50;
+    }
+
+    // Apply intensity to material directly to bypass React state
+    material.emissiveIntensity = intensidadActualRef.current / 100;
+
     // Rotación suave basada en la frecuencia
     const velocidad = frecuencia / 10000;
     grupoRef.current.rotation.y += velocidad;
     grupoRef.current.rotation.x = Math.sin(tiempo.current * 0.3) * 0.2;
 
-    // Pulsación basada en intensidad
-    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidad / 200);
+    // Pulsación basada en intensidad internalizada
+    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidadActualRef.current / 200);
     grupoRef.current.scale.setScalar(escala);
   });
 


### PR DESCRIPTION
💡 **What:** Internalized the 2-second intensity update interval from `EscenaMeditacion3D` directly into `GeometriaSagrada3D`'s `useFrame` loop using `useRef`.

🎯 **Why:** Previously, `EscenaMeditacion3D` used `useState` and `setInterval` to drive the animation. This forced React to reconcile and re-render the entire 3D canvas and component tree every 2 seconds. By moving the logic inside the `useFrame` loop and updating the Three.js material directly, we bypass React's render cycle completely. 

📊 **Impact:** 
- Eliminates 100% of the React reconciliation overhead caused by the animation.
- Converts the chunky 2-second interval updates into a smooth, frame-by-frame interpolation.
- Achieves O(1) performance for the animation state without triggering parent renders.

🔬 **Measurement:**
- Verify by interacting with the "Meditación 3D" tab. The 3D geometry now pulses smoothly instead of snapping every 2 seconds.
- Profiling the React tree will show no re-renders in `EscenaMeditacion3D` when the animation is active.

---
*PR created automatically by Jules for task [1567454517421649920](https://jules.google.com/task/1567454517421649920) started by @mexicodxnmexico-create*