### PR TITLE
🧪 [testing improvement] Add fractional beta value test for deviceorientation in QuantumMirror

### DIFF
--- a/tests/quantum-mirror.test.tsx
+++ b/tests/quantum-mirror.test.tsx
@@ -139,6 +139,52 @@ test('QuantumMirror deviceorientation logic', async (t) => {
     });
   });
 
+  await t.test('handles fractional beta values and rounds correctly', () => {
+    let root: TestRenderer.ReactTestRenderer | undefined;
+
+    TestRenderer.act(() => {
+      root = TestRenderer.create(<QuantumMirror />);
+    });
+
+    // Test rounding down
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 10, beta: 14.9, gamma: 10 });
+        });
+      }
+    });
+
+    let freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+    let betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
+
+    // 432 + Math.round(14.9 / 10) = 432 + Math.round(1.49) = 432 + 1 = 433
+    assert.strictEqual(freqDiv.children[0], '433');
+    assert.strictEqual(betaDiv.children[0], '14.9');
+
+    // Test rounding up
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 10, beta: 15.5, gamma: 10 });
+        });
+      }
+    });
+
+    freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+    betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
+
+    // 432 + Math.round(15.5 / 10) = 432 + Math.round(1.55) = 432 + 2 = 434
+    assert.strictEqual(freqDiv.children[0], '434');
+    assert.strictEqual(betaDiv.children[0], '15.5');
+
+    TestRenderer.act(() => {
+      root!.unmount();
+    });
+  });
+
   await t.test('handles missing event values gracefully', () => {
     let root: TestRenderer.ReactTestRenderer | undefined;
 


### PR DESCRIPTION
🎯 **What:** Added tests to verify the component `QuantumMirror.tsx` appropriately handles fractional `beta` values dispatched through `deviceorientation` events. 

📊 **Coverage:** Specifically tested scenarios rounding down (e.g. `14.9` -> `1`) and rounding up (e.g. `15.5` -> `2`) when passed through the `Math.round(e.beta / 10)` logic.

✨ **Result:** Test coverage improved by properly verifying standard browser event numerical output rather than relying solely on exact whole numbers in tests. Test suite execution passed alongside zero production breakages.

---
*PR created automatically by Jules for task [5162764912298154950](https://jules.google.com/task/5162764912298154950) started by @mexicodxnmexico-create*