### PR TITLE
⚡ Bolt: Optimize 3D Scene Reconciliation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,7 @@
 ## 2025-06-24 - Efficient Fixed-Size Array Updates
 **Learning:** Using `[...arr, item].slice(-N)` for maintaining a fixed-size buffer causes two array allocations (one for the spread and one for the final slice). While `shift()` is O(n), using `slice()` followed by `push()` and `shift()` is significantly faster because it minimizes heap pressure by avoiding the intermediate array allocation.
 **Action:** Prefer `slice()` + `push()` + `shift()` for more efficient memory management in state transitions.
+
+## 2025-06-25 - React Reconciliation in 3D Canvas
+**Learning:** Found that using a standard `setInterval` inside a parent component (`EscenaMeditacion3D`) to update a state variable (`intensidad`) caused the entire React Three Fiber `Canvas` and all of its 3D children to re-render every 2 seconds. This is a massive performance bottleneck for 3D applications, as it forces React reconciliation across the entire scene graph.
+**Action:** When child 3D components (`GeometriaSagrada3D`) need frequent but throttled updates, move the logic inside the component's own `useFrame` hook. Use `useRef` to store the value and another `useRef` to store the last update time (checking against `state.clock.elapsedTime`). Finally, update the Three.js material properties directly (e.g., `material.emissiveIntensity = ...`) to completely bypass React's render cycle for the animation.

--- a/components/3d/EscenaMeditacion3D.tsx
+++ b/components/3d/EscenaMeditacion3D.tsx
@@ -2,7 +2,7 @@
 
 import { Canvas } from "@react-three/fiber";
 import { OrbitControls, Stars, Environment } from "@react-three/drei";
-import { Suspense, useState, useEffect, memo } from "react";
+import { Suspense, memo } from "react";
 import { GeometriaSagrada3D } from "./GeometriaSagrada3D";
 import { ParticulasCuanticas } from "./ParticulasCuanticas";
 
@@ -14,20 +14,8 @@ interface EscenaMeditacion3DProps {
 
 // ⚡ BOLT: Wrap in React.memo to prevent massive 3D canvas re-renders caused by parent 1-second timers
 export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia, activo, tipoGeometria }: EscenaMeditacion3DProps) {
-  const [intensidad, setIntensidad] = useState(50);
-
-  useEffect(() => {
-    if (!activo) return;
-
-    const intervalo = setInterval(() => {
-      setIntensidad(prev => {
-        const nuevo = prev + (Math.random() - 0.5) * 10;
-        return Math.max(30, Math.min(70, nuevo));
-      });
-    }, 2000);
-
-    return () => clearInterval(intervalo);
-  }, [activo]);
+  // ⚡ BOLT OPTIMIZATION: Removed React state `intensidad` and `setInterval` to avoid React reconciliation
+  // every 2 seconds. The animation is now internalized in GeometriaSagrada3D's useFrame.
 
   return (
     <div style={{ width: "100%", height: "600px", borderRadius: "20px", overflow: "hidden" }}>
@@ -55,7 +43,7 @@ export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia,
 
           <GeometriaSagrada3D
             frecuencia={frecuencia}
-            intensidad={intensidad}
+            activo={activo}
             tipo={tipoGeometria}
           />
 

--- a/components/3d/GeometriaSagrada3D.tsx
+++ b/components/3d/GeometriaSagrada3D.tsx
@@ -6,13 +6,16 @@ import * as THREE from "three";
 
 interface GeometriaSagrada3DProps {
   frecuencia: number;
-  intensidad: number;
+  activo: boolean;
   tipo: "flor-vida" | "merkaba" | "metatron" | "torus";
 }
 
-export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSagrada3DProps) {
+export function GeometriaSagrada3D({ frecuencia, activo, tipo }: GeometriaSagrada3DProps) {
   const grupoRef = useRef<THREE.Group>(null);
   const tiempo = useRef(0);
+  // ⚡ BOLT OPTIMIZATION: Internalized intensity logic to avoid parent re-renders
+  const intensidadRef = useRef(50);
+  const ultimoUpdateIntensidad = useRef(0);
 
   // ⚡ OPTIMIZACIÓN: Calcular color basado en frecuencia solo cuando cambia
   const colorFrecuencia = useMemo(() => {
@@ -64,18 +67,28 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
   useEffect(() => {
     material.color.set(colorFrecuencia);
     material.emissive.set(colorFrecuencia);
-    material.emissiveIntensity = intensidad / 100;
-  }, [material, colorFrecuencia, intensidad]);
+    // emissiveIntensity is now driven by useFrame to prevent re-renders
+  }, [material, colorFrecuencia]);
 
   useEffect(() => {
     return () => material.dispose();
   }, [material]);
 
   // Animación continua
-  useFrame((_state, delta) => {
+  useFrame((state, delta) => {
     if (!grupoRef.current) return;
 
     tiempo.current += delta;
+
+    // ⚡ BOLT OPTIMIZATION: Throttled state update internalized inside useFrame
+    if (activo && state.clock.elapsedTime - ultimoUpdateIntensidad.current > 2) {
+      const nuevo = intensidadRef.current + (Math.random() - 0.5) * 10;
+      intensidadRef.current = Math.max(30, Math.min(70, nuevo));
+      ultimoUpdateIntensidad.current = state.clock.elapsedTime;
+    }
+
+    // Direct material update avoids React reconciliation
+    material.emissiveIntensity = intensidadRef.current / 100;
 
     // Rotación suave basada en la frecuencia
     const velocidad = frecuencia / 10000;
@@ -83,7 +96,7 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
     grupoRef.current.rotation.x = Math.sin(tiempo.current * 0.3) * 0.2;
 
     // Pulsación basada en intensidad
-    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidad / 200);
+    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidadRef.current / 200);
     grupoRef.current.scale.setScalar(escala);
   });
 


### PR DESCRIPTION
### 💡 What
Moved the throttled 2-second random intensity animation out of the parent component's (`EscenaMeditacion3D`) React state and internalized it using `useRef` inside the `GeometriaSagrada3D` child component's `useFrame` hook.

### 🎯 Why
Previously, the `setInterval` in the parent component updated a React state every 2 seconds, which triggered React reconciliation for the *entire* React Three Fiber `Canvas` and all its deeply nested 3D children. This is a severe anti-pattern for 3D performance, as WebGL scenes should bypass React's standard update cycle whenever possible to maintain a stable 60+ FPS framerate.

### 📊 Impact
* Eliminates massive DOM/Fiber reconciliation tree checks every 2 seconds.
* Animation logic is now $O(1)$ and decoupled entirely from the React component tree render cycle.
* Drastically improves framerate stability during the meditation visualization.

### 🔬 Measurement
To verify, you can use React DevTools Profiler. Start a meditation session. Previously, a large commit block would appear every 2 seconds for `Canvas` and all children. Now, only the initial render occurs, and subsequent animation is driven silently by the `useFrame` loop.

---
*PR created automatically by Jules for task [14480737360714547671](https://jules.google.com/task/14480737360714547671) started by @mexicodxnmexico-create*