### PR TITLE
🧪 Add test for QuantumMirror component deviceorientation fractional logic

### DIFF
--- a/tests/quantum-mirror.test.tsx
+++ b/tests/quantum-mirror.test.tsx
@@ -139,6 +139,69 @@ test('QuantumMirror deviceorientation logic', async (t) => {
     });
   });
 
+  await t.test('handles fractional beta values correctly with Math.round', () => {
+    let root: TestRenderer.ReactTestRenderer | undefined;
+
+    TestRenderer.act(() => {
+      root = TestRenderer.create(<QuantumMirror />);
+    });
+
+    // Test fractional values that should round down (e.g., 14.9 / 10 = 1.49 -> 1)
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 0, beta: 14.9, gamma: 0 });
+        });
+      }
+    });
+
+    let freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+    let betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
+
+    // 432 + Math.round(14.9 / 10) = 432 + 1 = 433
+    assert.strictEqual(freqDiv.children[0], '433');
+    assert.strictEqual(betaDiv.children[0], '14.9');
+
+    // Test fractional values that should round up (e.g., 15.1 / 10 = 1.51 -> 2)
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 0, beta: 15.1, gamma: 0 });
+        });
+      }
+    });
+
+    freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+    betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
+
+    // 432 + Math.round(15.1 / 10) = 432 + 2 = 434
+    assert.strictEqual(freqDiv.children[0], '434');
+    assert.strictEqual(betaDiv.children[0], '15.1');
+
+    // Test negative fractional values
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 0, beta: -15.1, gamma: 0 });
+        });
+      }
+    });
+
+    freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+    betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
+
+    // 432 + Math.round(-15.1 / 10) = 432 - 2 = 430
+    assert.strictEqual(freqDiv.children[0], '430');
+    assert.strictEqual(betaDiv.children[0], '-15.1');
+
+    TestRenderer.act(() => {
+      root!.unmount();
+    });
+  });
+
   await t.test('handles missing event values gracefully', () => {
     let root: TestRenderer.ReactTestRenderer | undefined;
 


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Added a test to ensure that the `deviceorientation` logic in `QuantumMirror` correctly handles fractional `beta` values. Previously, there was no coverage specifically verifying that `Math.round(beta / 10)` mathematically rounds up or down appropriately.

📊 **Coverage:** What scenarios are now tested
- Positive fractions that should round down (e.g., `beta: 14.9` -> `Math.round(1.49)` -> `1`)
- Positive fractions that should round up (e.g., `beta: 15.1` -> `Math.round(1.51)` -> `2`)
- Negative fractions that should round normally (e.g., `beta: -15.1` -> `Math.round(-1.51)` -> `-2`)

✨ **Result:** The improvement in test coverage
The component now has explicit coverage for floating-point values from the sensor API, slightly increasing overall branch coverage and significantly increasing confidence that the core math mapping works seamlessly in all tilting scenarios.

---
*PR created automatically by Jules for task [10219076741652009971](https://jules.google.com/task/10219076741652009971) started by @mexicodxnmexico-create*