### PR TITLE
⚡ Bolt: Bypass React reconciliation for 3D intensity animations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,6 @@
 ## 2025-06-24 - Efficient Fixed-Size Array Updates
 **Learning:** Using `[...arr, item].slice(-N)` for maintaining a fixed-size buffer causes two array allocations (one for the spread and one for the final slice). While `shift()` is O(n), using `slice()` followed by `push()` and `shift()` is significantly faster because it minimizes heap pressure by avoiding the intermediate array allocation.
 **Action:** Prefer `slice()` + `push()` + `shift()` for more efficient memory management in state transitions.
+## 2025-06-25 - React Three Fiber useFrame State Internalization
+**Learning:** Updating React state (e.g., via `setInterval` in a `useEffect`) to drive 3D animations causes the entire `Canvas` and its children to go through expensive React reconciliation passes.
+**Action:** When animating or updating properties at high frequencies or intervals, store the current value in a `useRef` and perform the update logic inside the `useFrame` loop, mutating the Three.js objects (like `material.emissiveIntensity`) directly. This bypasses React's render phase entirely and provides massive frame rate improvements.

--- a/components/3d/EscenaMeditacion3D.tsx
+++ b/components/3d/EscenaMeditacion3D.tsx
@@ -2,7 +2,7 @@
 
 import { Canvas } from "@react-three/fiber";
 import { OrbitControls, Stars, Environment } from "@react-three/drei";
-import { Suspense, useState, useEffect, memo } from "react";
+import { Suspense, memo } from "react";
 import { GeometriaSagrada3D } from "./GeometriaSagrada3D";
 import { ParticulasCuanticas } from "./ParticulasCuanticas";
 
@@ -14,21 +14,6 @@ interface EscenaMeditacion3DProps {
 
 // ⚡ BOLT: Wrap in React.memo to prevent massive 3D canvas re-renders caused by parent 1-second timers
 export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia, activo, tipoGeometria }: EscenaMeditacion3DProps) {
-  const [intensidad, setIntensidad] = useState(50);
-
-  useEffect(() => {
-    if (!activo) return;
-
-    const intervalo = setInterval(() => {
-      setIntensidad(prev => {
-        const nuevo = prev + (Math.random() - 0.5) * 10;
-        return Math.max(30, Math.min(70, nuevo));
-      });
-    }, 2000);
-
-    return () => clearInterval(intervalo);
-  }, [activo]);
-
   return (
     <div style={{ width: "100%", height: "600px", borderRadius: "20px", overflow: "hidden" }}>
       <Canvas
@@ -55,7 +40,7 @@ export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia,
 
           <GeometriaSagrada3D
             frecuencia={frecuencia}
-            intensidad={intensidad}
+            activo={activo}
             tipo={tipoGeometria}
           />
 

--- a/components/3d/GeometriaSagrada3D.tsx
+++ b/components/3d/GeometriaSagrada3D.tsx
@@ -6,13 +6,17 @@ import * as THREE from "three";
 
 interface GeometriaSagrada3DProps {
   frecuencia: number;
-  intensidad: number;
+  activo: boolean;
   tipo: "flor-vida" | "merkaba" | "metatron" | "torus";
 }
 
-export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSagrada3DProps) {
+export function GeometriaSagrada3D({ frecuencia, activo, tipo }: GeometriaSagrada3DProps) {
   const grupoRef = useRef<THREE.Group>(null);
   const tiempo = useRef(0);
+
+  // ⚡ BOLT: Internalize intensity calculation to avoid React re-renders
+  const intensidadRef = useRef(50);
+  const ultimaActualizacionRef = useRef(0);
 
   // ⚡ OPTIMIZACIÓN: Calcular color basado en frecuencia solo cuando cambia
   const colorFrecuencia = useMemo(() => {
@@ -64,8 +68,7 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
   useEffect(() => {
     material.color.set(colorFrecuencia);
     material.emissive.set(colorFrecuencia);
-    material.emissiveIntensity = intensidad / 100;
-  }, [material, colorFrecuencia, intensidad]);
+  }, [material, colorFrecuencia]);
 
   useEffect(() => {
     return () => material.dispose();
@@ -77,13 +80,26 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
 
     tiempo.current += delta;
 
+    // ⚡ BOLT: Handle intensity updates entirely inside the useFrame loop
+    // to prevent parent component re-renders every 2 seconds.
+    if (activo) {
+      if (tiempo.current - ultimaActualizacionRef.current > 2) {
+        ultimaActualizacionRef.current = tiempo.current;
+        const nuevo = intensidadRef.current + (Math.random() - 0.5) * 10;
+        intensidadRef.current = Math.max(30, Math.min(70, nuevo));
+      }
+    }
+
+    // Direct mutation of the material property avoids React effect scheduling overhead
+    material.emissiveIntensity = intensidadRef.current / 100;
+
     // Rotación suave basada en la frecuencia
     const velocidad = frecuencia / 10000;
     grupoRef.current.rotation.y += velocidad;
     grupoRef.current.rotation.x = Math.sin(tiempo.current * 0.3) * 0.2;
 
-    // Pulsación basada en intensidad
-    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidad / 200);
+    // Pulsación basada en intensidad internalizada
+    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidadRef.current / 200);
     grupoRef.current.scale.setScalar(escala);
   });
 


### PR DESCRIPTION
💡 **What:** Internalized the `intensidad` calculation (previously updated every 2 seconds via `setInterval` and React `useState` in `EscenaMeditacion3D`) into a `useRef` updated directly inside the `useFrame` loop of `GeometriaSagrada3D`. Directly mutates the Three.js material inside the frame loop.

🎯 **Why:** Updating standard React state to drive 3D scene properties causes expensive React reconciliation phases across the entire `<Canvas>` component and all of its 3D children. This causes significant, unnecessary garbage collection and main-thread blocking overhead.

📊 **Impact:** Reduces React re-renders of the heavy 3D Meditation Scene by 100% during steady-state visualization. Frame stability is improved because property mutations (like material intensity) now bypass React's asynchronous render cycle entirely. 

🔬 **Measurement:** Verify by placing a `console.log("RENDER")` at the top level of `EscenaMeditacion3D` and `GeometriaSagrada3D`. Before this change, it fired every 2 seconds. After this change, it only fires on initial mount or when the `frecuencia`/`activo` props change.

---
*PR created automatically by Jules for task [12410737463557056074](https://jules.google.com/task/12410737463557056074) started by @mexicodxnmexico-create*