### PR TITLE
🧪 Add tests for deviceorientation fractional rounding logic

### DIFF
--- a/tests/quantum-mirror.test.tsx
+++ b/tests/quantum-mirror.test.tsx
@@ -139,6 +139,63 @@ test('QuantumMirror deviceorientation logic', async (t) => {
     });
   });
 
+  await t.test('handles fractional beta values for rounding logic', () => {
+    let root: TestRenderer.ReactTestRenderer | undefined;
+
+    TestRenderer.act(() => {
+      root = TestRenderer.create(<QuantumMirror />);
+    });
+
+    const freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+    const betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
+
+    // Test rounding down (e.g., 4.49 -> 0, freq 432 + 0 = 432)
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 0, beta: 4.9, gamma: 0 }); // 4.9 / 10 = 0.49 -> rounds to 0
+        });
+      }
+    });
+
+    // 432 + Math.round(4.9 / 10) = 432 + 0 = 432
+    assert.strictEqual(freqDiv.children[0], '432');
+    assert.strictEqual(betaDiv.children[0], '4.9');
+
+    // Test rounding up (e.g., 5.1 -> 1, freq 432 + 1 = 433)
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 0, beta: 5.1, gamma: 0 }); // 5.1 / 10 = 0.51 -> rounds to 1
+        });
+      }
+    });
+
+    // 432 + Math.round(5.1 / 10) = 432 + 1 = 433
+    assert.strictEqual(freqDiv.children[0], '433');
+    assert.strictEqual(betaDiv.children[0], '5.1');
+
+    // Test negative rounding (e.g., -5.1 -> -1, freq 432 - 1 = 431)
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 0, beta: -5.1, gamma: 0 }); // -5.1 / 10 = -0.51 -> rounds to -1
+        });
+      }
+    });
+
+    // 432 + Math.round(-5.1 / 10) = 432 - 1 = 431
+    assert.strictEqual(freqDiv.children[0], '431');
+    assert.strictEqual(betaDiv.children[0], '-5.1');
+
+    TestRenderer.act(() => {
+      root!.unmount();
+    });
+  });
+
   await t.test('handles missing event values gracefully', () => {
     let root: TestRenderer.ReactTestRenderer | undefined;
 


### PR DESCRIPTION
🎯 **What:** The `QuantumMirror` component lacked specific test cases validating its rounding logic `Math.round(e.beta / 10)` on `deviceorientation` events. Added tests to explicitly check how fractional inputs trigger upward, downward, and negative rounding accurately.

📊 **Coverage:** Covered missing test conditions for `handles fractional beta values for rounding logic`. Tested edge cases for fractional limits (e.g. 4.9 rounding down, 5.1 rounding up, -5.1 rounding to -1).

✨ **Result:** Test coverage for `QuantumMirror.tsx` is strictly more comprehensive in verifying accurate sensor transformations, ensuring logic updates do not break frequency math.

---
*PR created automatically by Jules for task [13452556491890524422](https://jules.google.com/task/13452556491890524422) started by @mexicodxnmexico-create*