### PR TITLE
⚡ Bolt: Internalize 3D animation to bypass React re-renders

### DIFF
--- a/components/3d/EscenaMeditacion3D.tsx
+++ b/components/3d/EscenaMeditacion3D.tsx
@@ -14,21 +14,6 @@ interface EscenaMeditacion3DProps {
 
 // ⚡ BOLT: Wrap in React.memo to prevent massive 3D canvas re-renders caused by parent 1-second timers
 export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia, activo, tipoGeometria }: EscenaMeditacion3DProps) {
-  const [intensidad, setIntensidad] = useState(50);
-
-  useEffect(() => {
-    if (!activo) return;
-
-    const intervalo = setInterval(() => {
-      setIntensidad(prev => {
-        const nuevo = prev + (Math.random() - 0.5) * 10;
-        return Math.max(30, Math.min(70, nuevo));
-      });
-    }, 2000);
-
-    return () => clearInterval(intervalo);
-  }, [activo]);
-
   return (
     <div style={{ width: "100%", height: "600px", borderRadius: "20px", overflow: "hidden" }}>
       <Canvas
@@ -55,7 +40,7 @@ export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia,
 
           <GeometriaSagrada3D
             frecuencia={frecuencia}
-            intensidad={intensidad}
+            activo={activo}
             tipo={tipoGeometria}
           />
 

--- a/components/3d/GeometriaSagrada3D.tsx
+++ b/components/3d/GeometriaSagrada3D.tsx
@@ -1,18 +1,20 @@
 "use client";
 
-import { useRef, useMemo, useEffect } from "react";
+import { useRef, useMemo, useEffect, memo } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
 interface GeometriaSagrada3DProps {
   frecuencia: number;
-  intensidad: number;
+  activo: boolean;
   tipo: "flor-vida" | "merkaba" | "metatron" | "torus";
 }
 
-export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSagrada3DProps) {
+export const GeometriaSagrada3D = memo(function GeometriaSagrada3D({ frecuencia, activo, tipo }: GeometriaSagrada3DProps) {
   const grupoRef = useRef<THREE.Group>(null);
   const tiempo = useRef(0);
+  const intensidadRef = useRef(50);
+  const ultimoUpdateIntensidad = useRef(0);
 
   // ⚡ OPTIMIZACIÓN: Calcular color basado en frecuencia solo cuando cambia
   const colorFrecuencia = useMemo(() => {
@@ -64,8 +66,8 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
   useEffect(() => {
     material.color.set(colorFrecuencia);
     material.emissive.set(colorFrecuencia);
-    material.emissiveIntensity = intensidad / 100;
-  }, [material, colorFrecuencia, intensidad]);
+    material.emissiveIntensity = intensidadRef.current / 100;
+  }, [material, colorFrecuencia]);
 
   useEffect(() => {
     return () => material.dispose();
@@ -77,13 +79,23 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
 
     tiempo.current += delta;
 
+    // ⚡ BOLT: Internalized intensity animation to bypass React re-renders.
+    // Update intensity every 2 seconds if active, mirroring original logic.
+    if (activo && tiempo.current - ultimoUpdateIntensidad.current > 2) {
+      intensidadRef.current = Math.max(30, Math.min(70, intensidadRef.current + (Math.random() - 0.5) * 10));
+      ultimoUpdateIntensidad.current = tiempo.current;
+
+      // Update material property directly
+      material.emissiveIntensity = intensidadRef.current / 100;
+    }
+
     // Rotación suave basada en la frecuencia
     const velocidad = frecuencia / 10000;
     grupoRef.current.rotation.y += velocidad;
     grupoRef.current.rotation.x = Math.sin(tiempo.current * 0.3) * 0.2;
 
-    // Pulsación basada en intensidad
-    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidad / 200);
+    // Pulsación basada en intensidad (updated directly in frame loop)
+    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidadRef.current / 200);
     grupoRef.current.scale.setScalar(escala);
   });
 
@@ -94,7 +106,7 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
       ))}
     </group>
   );
-}
+});
 
 interface GeoData {
   geometria: THREE.BufferGeometry;

--- a/components/3d/ParticulasCuanticas.tsx
+++ b/components/3d/ParticulasCuanticas.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useMemo } from "react";
+import { useRef, useMemo, memo } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
@@ -19,7 +19,7 @@ const COLORES_SOLFEGGIO: Record<number, { r: number; g: number; b: number }> = {
   852: { r: 0.51, g: 0.22, b: 0.93 }
 };
 
-export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuanticasProps) {
+export const ParticulasCuanticas = memo(function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuanticasProps) {
   const particulasRef = useRef<THREE.Points>(null);
   const tiempo = useRef(0);
 
@@ -128,4 +128,4 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
       />
     </points>
   );
-}
+});


### PR DESCRIPTION
💡 What: Internalized the `intensidad` (intensity) animation logic from `EscenaMeditacion3D` into `GeometriaSagrada3D` using `useRef` and the `useFrame` loop. Also wrapped 3D components in `React.memo`.

🎯 Why: Previously, a `setInterval` in the parent component triggered a React re-render every 2 seconds, causing the entire 3D Canvas and its children to undergo reconciliation.

📊 Impact: Eliminates periodic React re-renders of the 3D scene during meditation, significantly reducing CPU overhead and improving frame stability.

🔬 Measurement: Verified that `GeometriaSagrada3D` now manages its own animation state without triggering parent re-renders (can be verified with React DevTools or console logs in the component body).

---
*PR created automatically by Jules for task [11670059964768786124](https://jules.google.com/task/11670059964768786124) started by @mexicodxnmexico-create*