### PR TITLE
🎨 Palette: Add semantic ARIA tabs for main navigation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,7 +27,7 @@ const H1_STYLE: CSSProperties = { fontSize: "3.5rem", marginBottom: "1rem", lett
 const STATUS_STYLE: CSSProperties = { fontSize: "1.25rem", color: "#666", maxWidth: "600px", margin: "0 auto" };
 const FOOTER_STYLE: CSSProperties = { padding: "4rem 0", textAlign: "center", borderTop: "1px solid #eaeaea", color: "#555", fontSize: "0.8rem" };
 const TABS_STYLE: CSSProperties = { display: "flex", justifyContent: "center", gap: "1rem", marginBottom: "2rem" };
-const TAB_BUTTON_STYLE: CSSProperties = { padding: "0.5rem 1rem", border: "1px solid #ccc", borderRadius: "4px", background: "none", cursor: "pointer", fontSize: "1rem" };
+const TAB_BUTTON_STYLE: CSSProperties = { padding: "0.5rem 1rem", border: "1px solid #ccc", borderRadius: "4px", background: "none", cursor: "pointer", fontSize: "1rem", transition: "all 0.2s ease" };
 const TAB_BUTTON_ACTIVE_STYLE: CSSProperties = { ...TAB_BUTTON_STYLE, background: "#000", color: "#fff", borderColor: "#000" };
 
 export default function Home() {
@@ -68,14 +68,22 @@ export default function Home() {
 
       <Header />
 
-      <div style={TABS_STYLE}>
+      <div style={TABS_STYLE} role="tablist" aria-label="Vistas de la aplicación">
         <button
+          role="tab"
+          id="tab-espejo"
+          aria-selected={activeTab === "espejo"}
+          aria-controls="panel-espejo"
           style={activeTab === "espejo" ? TAB_BUTTON_ACTIVE_STYLE : TAB_BUTTON_STYLE}
           onClick={() => setActiveTab("espejo")}
         >
           Espejo Cuántico
         </button>
         <button
+          role="tab"
+          id="tab-meditacion"
+          aria-selected={activeTab === "meditacion"}
+          aria-controls="panel-meditacion"
           style={activeTab === "meditacion" ? TAB_BUTTON_ACTIVE_STYLE : TAB_BUTTON_STYLE}
           onClick={() => setActiveTab("meditacion")}
         >
@@ -85,7 +93,7 @@ export default function Home() {
 
       <main style={MAIN_STYLE}>
         {activeTab === "espejo" ? (
-          <>
+          <div role="tabpanel" id="panel-espejo" aria-labelledby="tab-espejo">
             <section style={HEADER_SECTION_STYLE}>
               <h1 style={H1_STYLE}>Espejo Cuántico</h1>
               <p role="status" aria-live="polite" style={STATUS_STYLE}>
@@ -102,9 +110,11 @@ export default function Home() {
             )}
 
             <HistorySection historyToRender={historyToRender} startIndex={startIndex} />
-          </>
+          </div>
         ) : (
-          <MeditacionAudioVisual3D onCompletarMeditacion={() => setActiveTab("espejo")} />
+          <div role="tabpanel" id="panel-meditacion" aria-labelledby="tab-meditacion">
+            <MeditacionAudioVisual3D onCompletarMeditacion={() => setActiveTab("espejo")} />
+          </div>
         )}
       </main>
 


### PR DESCRIPTION
### 💡 What
Added semantic HTML attributes (`role="tablist"`, `role="tab"`, `role="tabpanel"`, etc.) to the main navigation toggle on the `app/page.tsx` screen, and added a subtle transition to the tab buttons.

### 🎯 Why
The custom tab toggles ("Espejo Cuántico" and "Meditación 3D") were previously just a pair of `<button>`s inside a `<div>`, modifying application state. They provided no semantic context to screen readers that they functioned as a tabbed interface. Furthermore, the active/inactive state switches lacked visual polish.

### 📸 Before/After
**Before:**
```tsx
<div style={TABS_STYLE}>
  <button style={...} onClick={...}>Espejo Cuántico</button>
  <button style={...} onClick={...}>Meditación 3D</button>
</div>
```

**After:**
```tsx
<div style={TABS_STYLE} role="tablist" aria-label="Vistas de la aplicación">
  <button role="tab" aria-selected={activeTab === "espejo"} aria-controls="panel-espejo" ...>Espejo Cuántico</button>
  <button role="tab" aria-selected={activeTab === "meditacion"} aria-controls="panel-meditacion" ...>Meditación 3D</button>
</div>
```
*(With corresponding `role="tabpanel"` elements for the content areas, and a CSS transition `all 0.2s ease` on the buttons).*

### ♿ Accessibility
*   **Semantic Structure:** Screen readers now announce the main navigation area as a list of tabs, allowing users to understand the relationship between the two views.
*   **Active State Identification:** Screen readers will correctly announce which view is currently active via the `aria-selected` attribute.
*   **Content Association:** Content sections are now explicitly linked to their corresponding tabs via `aria-controls` and `aria-labelledby`.

---
*PR created automatically by Jules for task [8492849226274634042](https://jules.google.com/task/8492849226274634042) started by @mexicodxnmexico-create*