### PR TITLE
🧪 [testing improvement] Add fractional tests for QuantumMirror deviceorientation rounding

### DIFF
--- a/tests/quantum-mirror.test.tsx
+++ b/tests/quantum-mirror.test.tsx
@@ -139,6 +139,63 @@ test('QuantumMirror deviceorientation logic', async (t) => {
     });
   });
 
+  await t.test('handles fractional beta values and rounds correctly', () => {
+    let root: TestRenderer.ReactTestRenderer | undefined;
+
+    TestRenderer.act(() => {
+      root = TestRenderer.create(<QuantumMirror />);
+    });
+
+    // Test rounding down (e.g. 4.49 -> 4)
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 10, beta: 44.9, gamma: 10 });
+        });
+      }
+    });
+
+    const freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+    const betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
+
+    // 432 + Math.round(44.9 / 10) = 432 + Math.round(4.49) = 432 + 4 = 436
+    assert.strictEqual(freqDiv.children[0], '436');
+    assert.strictEqual(betaDiv.children[0], '44.9');
+
+    // Test rounding up (e.g. 4.5 -> 5)
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 10, beta: 45.0, gamma: 10 });
+        });
+      }
+    });
+
+    // 432 + Math.round(45.0 / 10) = 432 + Math.round(4.5) = 432 + 5 = 437
+    assert.strictEqual(freqDiv.children[0], '437');
+    assert.strictEqual(betaDiv.children[0], '45');
+
+    // Test rounding up past half (e.g. 4.51 -> 5)
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 10, beta: 45.1, gamma: 10 });
+        });
+      }
+    });
+
+    // 432 + Math.round(45.1 / 10) = 432 + Math.round(4.51) = 432 + 5 = 437
+    assert.strictEqual(freqDiv.children[0], '437');
+    assert.strictEqual(betaDiv.children[0], '45.1');
+
+    TestRenderer.act(() => {
+      root!.unmount();
+    });
+  });
+
   await t.test('handles missing event values gracefully', () => {
     let root: TestRenderer.ReactTestRenderer | undefined;
 


### PR DESCRIPTION
🎯 **What:** The testing gap regarding fractional `beta` values not being checked against `Math.round()` logic in `QuantumMirror.tsx` is now addressed.

📊 **Coverage:** Explicitly added cases checking fractional numbers near the `.5` threshold rounding down (`44.9 / 10 -> 4.49 -> 4`) and rounding up (`45.0 / 10 -> 4.5 -> 5` and `45.1 / 10 -> 4.51 -> 5`). This guarantees the frequency calculations compute correctly.

✨ **Result:** Enhanced test stability and ensured the logic handles actual sensor values appropriately without regression. Full test suite and lint checks ran successfully.

---
*PR created automatically by Jules for task [6920741068318299481](https://jules.google.com/task/6920741068318299481) started by @mexicodxnmexico-create*