### PR TITLE
🎨 Palette: Enhance tab navigation accessibility

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,7 +27,7 @@ const H1_STYLE: CSSProperties = { fontSize: "3.5rem", marginBottom: "1rem", lett
 const STATUS_STYLE: CSSProperties = { fontSize: "1.25rem", color: "#666", maxWidth: "600px", margin: "0 auto" };
 const FOOTER_STYLE: CSSProperties = { padding: "4rem 0", textAlign: "center", borderTop: "1px solid #eaeaea", color: "#555", fontSize: "0.8rem" };
 const TABS_STYLE: CSSProperties = { display: "flex", justifyContent: "center", gap: "1rem", marginBottom: "2rem" };
-const TAB_BUTTON_STYLE: CSSProperties = { padding: "0.5rem 1rem", border: "1px solid #ccc", borderRadius: "4px", background: "none", cursor: "pointer", fontSize: "1rem" };
+const TAB_BUTTON_STYLE: CSSProperties = { padding: "0.5rem 1rem", borderStyle: "solid", borderWidth: "1px", borderColor: "#ccc", borderRadius: "4px", background: "none", cursor: "pointer", fontSize: "1rem" };
 const TAB_BUTTON_ACTIVE_STYLE: CSSProperties = { ...TAB_BUTTON_STYLE, background: "#000", color: "#fff", borderColor: "#000" };
 
 export default function Home() {
@@ -62,22 +62,47 @@ export default function Home() {
 
   if (loading) return <div style={LOADING_STYLE}>Sincronizando con el núcleo...</div>;
 
+  const handleTabKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
+      const nextTab = activeTab === "espejo" ? "meditacion" : "espejo";
+      setActiveTab(nextTab);
+
+      // Wait for React to render the new active tab, then focus it
+      setTimeout(() => {
+        const nextButton = document.getElementById(`tab-${nextTab}`);
+        if (nextButton) nextButton.focus();
+      }, 0);
+    }
+  };
+
   return (
     <div style={CONTAINER_STYLE}>
       {showOnboarding && <Onboarding onComplete={completeOnboarding} />}
 
       <Header />
 
-      <div style={TABS_STYLE}>
+      <div style={TABS_STYLE} role="tablist" aria-label="Modos de la aplicación">
         <button
+          id="tab-espejo"
+          role="tab"
+          aria-selected={activeTab === "espejo"}
+          aria-controls="panel-espejo"
+          tabIndex={activeTab === "espejo" ? 0 : -1}
           style={activeTab === "espejo" ? TAB_BUTTON_ACTIVE_STYLE : TAB_BUTTON_STYLE}
           onClick={() => setActiveTab("espejo")}
+          onKeyDown={handleTabKeyDown}
         >
           Espejo Cuántico
         </button>
         <button
+          id="tab-meditacion"
+          role="tab"
+          aria-selected={activeTab === "meditacion"}
+          aria-controls="panel-meditacion"
+          tabIndex={activeTab === "meditacion" ? 0 : -1}
           style={activeTab === "meditacion" ? TAB_BUTTON_ACTIVE_STYLE : TAB_BUTTON_STYLE}
           onClick={() => setActiveTab("meditacion")}
+          onKeyDown={handleTabKeyDown}
         >
           Meditación 3D
         </button>
@@ -85,7 +110,7 @@ export default function Home() {
 
       <main style={MAIN_STYLE}>
         {activeTab === "espejo" ? (
-          <>
+          <div id="panel-espejo" role="tabpanel" aria-labelledby="tab-espejo" tabIndex={0}>
             <section style={HEADER_SECTION_STYLE}>
               <h1 style={H1_STYLE}>Espejo Cuántico</h1>
               <p role="status" aria-live="polite" style={STATUS_STYLE}>
@@ -102,9 +127,11 @@ export default function Home() {
             )}
 
             <HistorySection historyToRender={historyToRender} startIndex={startIndex} />
-          </>
+          </div>
         ) : (
-          <MeditacionAudioVisual3D onCompletarMeditacion={() => setActiveTab("espejo")} />
+          <div id="panel-meditacion" role="tabpanel" aria-labelledby="tab-meditacion" tabIndex={0}>
+            <MeditacionAudioVisual3D onCompletarMeditacion={() => setActiveTab("espejo")} />
+          </div>
         )}
       </main>
 

--- a/components/HistorySection.tsx
+++ b/components/HistorySection.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, memo, useMemo } from "react";
+import { CSSProperties, memo } from "react";
 
 const HISTORY_SECTION_STYLE: CSSProperties = { marginBottom: "1.5rem" };
 const LOG_CONTAINER_STYLE: CSSProperties = {


### PR DESCRIPTION
💡 **What:** Added WAI-ARIA standard roles (`tablist`, `tab`, `tabpanel`), aria states (`aria-selected`, `aria-controls`), and keyboard navigation (ArrowLeft/ArrowRight) to the tab navigation that switches between "Espejo Cuántico" and "Meditación 3D".
🎯 **Why:** To make the application's primary navigation mode accessible to screen readers and fully usable via keyboard, improving the overall UX for all users.
📸 **Before/After:** The visual appearance remains the same, but the DOM structure and keyboard interaction have been significantly improved.
♿ **Accessibility:**
- Added `role="tablist"` to the tab container.
- Added `role="tab"`, `aria-selected`, `aria-controls`, and `id` to the tab buttons.
- Added `role="tabpanel"` and `tabIndex={0}` to the content sections.
- Implemented `onKeyDown` on the tabs to allow users to switch tabs using their keyboard arrows and smoothly shift focus.

---
*PR created automatically by Jules for task [2909370762996077041](https://jules.google.com/task/2909370762996077041) started by @mexicodxnmexico-create*