### PR TITLE
⚡ Bolt: Optimize React Three Fiber visual updates with native useFrame

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,7 @@
 ## 2025-06-24 - Efficient Fixed-Size Array Updates
 **Learning:** Using `[...arr, item].slice(-N)` for maintaining a fixed-size buffer causes two array allocations (one for the spread and one for the final slice). While `shift()` is O(n), using `slice()` followed by `push()` and `shift()` is significantly faster because it minimizes heap pressure by avoiding the intermediate array allocation.
 **Action:** Prefer `slice()` + `push()` + `shift()` for more efficient memory management in state transitions.
+
+## 2026-04-18 - React Three Fiber Direct Visual Updates
+**Learning:** In a high-frequency context like React Three Fiber, wrapping visual oscillations (like pulsing emissive intensity or scaling) in a React state with `setInterval` causes massive reconciliation and redundant re-renders. It blocks the main thread unnecessarily because it forces React to map changes that can just be updated natively on the Three.js mesh directly.
+**Action:** Replicate the interval/timer logic directly inside `useFrame` by maintaining references (`useRef`) for the state and the timestamp. Then update the `mesh.material` or `mesh.scale` mutably to bypass the React render cycle entirely, leading to much better visual performance and reduced CPU overhead.

--- a/components/3d/EscenaMeditacion3D.tsx
+++ b/components/3d/EscenaMeditacion3D.tsx
@@ -2,7 +2,7 @@
 
 import { Canvas } from "@react-three/fiber";
 import { OrbitControls, Stars, Environment } from "@react-three/drei";
-import { Suspense, useState, useEffect, memo } from "react";
+import { Suspense, memo } from "react";
 import { GeometriaSagrada3D } from "./GeometriaSagrada3D";
 import { ParticulasCuanticas } from "./ParticulasCuanticas";
 
@@ -14,21 +14,6 @@ interface EscenaMeditacion3DProps {
 
 // ⚡ BOLT: Wrap in React.memo to prevent massive 3D canvas re-renders caused by parent 1-second timers
 export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia, activo, tipoGeometria }: EscenaMeditacion3DProps) {
-  const [intensidad, setIntensidad] = useState(50);
-
-  useEffect(() => {
-    if (!activo) return;
-
-    const intervalo = setInterval(() => {
-      setIntensidad(prev => {
-        const nuevo = prev + (Math.random() - 0.5) * 10;
-        return Math.max(30, Math.min(70, nuevo));
-      });
-    }, 2000);
-
-    return () => clearInterval(intervalo);
-  }, [activo]);
-
   return (
     <div style={{ width: "100%", height: "600px", borderRadius: "20px", overflow: "hidden" }}>
       <Canvas
@@ -55,7 +40,7 @@ export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia,
 
           <GeometriaSagrada3D
             frecuencia={frecuencia}
-            intensidad={intensidad}
+            activo={activo}
             tipo={tipoGeometria}
           />
 

--- a/components/3d/GeometriaSagrada3D.tsx
+++ b/components/3d/GeometriaSagrada3D.tsx
@@ -6,13 +6,15 @@ import * as THREE from "three";
 
 interface GeometriaSagrada3DProps {
   frecuencia: number;
-  intensidad: number;
+  activo: boolean;
   tipo: "flor-vida" | "merkaba" | "metatron" | "torus";
 }
 
-export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSagrada3DProps) {
+export function GeometriaSagrada3D({ frecuencia, activo, tipo }: GeometriaSagrada3DProps) {
   const grupoRef = useRef<THREE.Group>(null);
   const tiempo = useRef(0);
+  const intensidadRef = useRef(50);
+  const ultimoRef = useRef(0);
 
   // ⚡ OPTIMIZACIÓN: Calcular color basado en frecuencia solo cuando cambia
   const colorFrecuencia = useMemo(() => {
@@ -64,8 +66,9 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
   useEffect(() => {
     material.color.set(colorFrecuencia);
     material.emissive.set(colorFrecuencia);
-    material.emissiveIntensity = intensidad / 100;
-  }, [material, colorFrecuencia, intensidad]);
+    // emissiveIntensity is now managed in useFrame to avoid React re-renders
+    material.emissiveIntensity = intensidadRef.current / 100;
+  }, [material, colorFrecuencia]);
 
   useEffect(() => {
     return () => material.dispose();
@@ -82,8 +85,17 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
     grupoRef.current.rotation.y += velocidad;
     grupoRef.current.rotation.x = Math.sin(tiempo.current * 0.3) * 0.2;
 
+    // ⚡ BOLT: Replicate throttled interval logic natively in useFrame
+    if (activo && tiempo.current - ultimoRef.current > 2) {
+      const nuevo = intensidadRef.current + (Math.random() - 0.5) * 10;
+      intensidadRef.current = Math.max(30, Math.min(70, nuevo));
+      ultimoRef.current = tiempo.current;
+      // Update material directly
+      material.emissiveIntensity = intensidadRef.current / 100;
+    }
+
     // Pulsación basada en intensidad
-    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidad / 200);
+    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidadRef.current / 200);
     grupoRef.current.scale.setScalar(escala);
   });
 

--- a/components/HistorySection.tsx
+++ b/components/HistorySection.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, memo, useMemo } from "react";
+import { CSSProperties, memo } from "react";
 
 const HISTORY_SECTION_STYLE: CSSProperties = { marginBottom: "1.5rem" };
 const LOG_CONTAINER_STYLE: CSSProperties = {


### PR DESCRIPTION
💡 **What**: Moved visual oscillation timers out of React's `useState` in `EscenaMeditacion3D` and migrated them to mutable `useRef` updates managed natively inside `@react-three/fiber`'s high-frequency `useFrame` loop within `GeometriaSagrada3D`.

🎯 **Why**: Using `setInterval` coupled with React `useState` to drive 3D material properties (like pulsing emissive intensity) causes React to reconcile and re-render the expensive `<Canvas>` and its children every two seconds. This blocks the main thread unnecessarily because visual updates can be applied directly to the Three.js mesh mutably.

📊 **Impact**: Reduces parent component re-renders from once every 2 seconds to 0 during the meditation sequence. Achieves near-zero CPU overhead for the pulsing visual effect, improving frame stability and preventing main thread stuttering.

🔬 **Measurement**: Verified by ensuring the visual pulse continues accurately based on the throttled 2-second timestamp delta within `useFrame`. Ran `npx tsx --test tests/*.test.ts tests/*.test.tsx` and `npx eslint .` to ensure no regressions or type errors.

---
*PR created automatically by Jules for task [13175555478778830684](https://jules.google.com/task/13175555478778830684) started by @mexicodxnmexico-create*