### PR TITLE
🧪 [test: quantum-mirror fractional beta tests]

### DIFF
--- a/tests/quantum-mirror.test.tsx
+++ b/tests/quantum-mirror.test.tsx
@@ -139,6 +139,48 @@ test('QuantumMirror deviceorientation logic', async (t) => {
     });
   });
 
+  await t.test('handles fractional beta values correctly based on Math.round', () => {
+    let root: TestRenderer.ReactTestRenderer | undefined;
+
+    TestRenderer.act(() => {
+      root = TestRenderer.create(<QuantumMirror />);
+    });
+
+    // Test rounding up (e.g. 45.5 / 10 = 4.55 => 5)
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 10, beta: 45.5, gamma: 10 });
+        });
+      }
+    });
+
+    let freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+    let betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
+    assert.strictEqual(freqDiv.children[0], '437'); // 432 + Math.round(45.5/10) = 432 + 5 = 437
+    assert.strictEqual(betaDiv.children[0], '45.5');
+
+    // Test rounding down (e.g. 44.4 / 10 = 4.44 => 4)
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 10, beta: 44.4, gamma: 10 });
+        });
+      }
+    });
+
+    freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+    betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
+    assert.strictEqual(freqDiv.children[0], '436'); // 432 + Math.round(44.4/10) = 432 + 4 = 436
+    assert.strictEqual(betaDiv.children[0], '44.4');
+
+    TestRenderer.act(() => {
+      root!.unmount();
+    });
+  });
+
   await t.test('handles missing event values gracefully', () => {
     let root: TestRenderer.ReactTestRenderer | undefined;
 


### PR DESCRIPTION
🎯 **What:** The testing gap in `QuantumMirror.tsx` for handling the `Math.round` logic on fractional `beta` values was addressed.
📊 **Coverage:** A test scenario covering fractional beta values rounding up (e.g., `45.5`) and rounding down (e.g., `44.4`) has been added.
✨ **Result:** Increased test coverage inside the `deviceorientation` logic mapping to accurately assert math calculations and frequency updates inside the sensor listener.

---
*PR created automatically by Jules for task [5704096565863066278](https://jules.google.com/task/5704096565863066278) started by @mexicodxnmexico-create*