### PR TITLE
🎨 Palette: Fix form accessibility in Meditación 3D

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-03-15 - Critical Error State Accessibility
 **Learning:** When a system enters a critical error or collapsed state that disables primary UI interactions, simply rendering the state is insufficient. It requires 'role="alert"' to announce the critical state and explicit focus shifting (via 'autoFocus' or 'useEffect' with 'useRef') to the primary recovery action to maintain accessibility.
 **Action:** Always add 'role="alert"' to error containers and explicitly shift focus to the recovery button or primary text when a disruptive error state mounts.
+
+## 2024-05-25 - Semantic Form Labels
+**Learning:** Using structural elements like `<h3>` as pseudo-labels for form controls breaks screen reader association and creates confusing document outlines.
+**Action:** Always use semantic `<label>` elements linked via `htmlFor` and `id` to ensure proper accessibility and context for assistive technologies.

--- a/components/HistorySection.tsx
+++ b/components/HistorySection.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, memo, useMemo } from "react";
+import { CSSProperties, memo } from "react";
 
 const HISTORY_SECTION_STYLE: CSSProperties = { marginBottom: "1.5rem" };
 const LOG_CONTAINER_STYLE: CSSProperties = {

--- a/components/meditacion/MeditacionAudioVisual3D.tsx
+++ b/components/meditacion/MeditacionAudioVisual3D.tsx
@@ -146,10 +146,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="frecuencia" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Frecuencia Solfeggio
-          </h3>
+          </label>
           <select
+            id="frecuencia"
             value={frecuenciaSeleccionada}
             onChange={(e) => setFrecuenciaSeleccionada(Number(e.target.value))}
             disabled={activo}
@@ -176,10 +177,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="geometria" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Geometría Sagrada
-          </h3>
+          </label>
           <select
+            id="geometria"
             value={geometriaSeleccionada}
             onChange={(e) => setGeometriaSeleccionada(e.target.value as any)}
             disabled={activo}
@@ -206,10 +208,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="duracion" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Duración (minutos)
-          </h3>
+          </label>
           <input
+            id="duracion"
             type="number"
             min="1"
             max="60"


### PR DESCRIPTION
💡 **What:** Replaced structural `<h3>` elements acting as pseudo-labels with semantic `<label>` elements in the Meditación 3D form controls. Linked the new labels to their respective `<select>` and `<input>` elements using `htmlFor` and `id` attributes. Removed an unused `useMemo` import in `HistorySection.tsx` to fix a linter warning during build.

🎯 **Why:** Structural headers do not provide programmatic association for form controls, making them inaccessible to screen readers. Semantic labels ensure that assistive technologies can correctly identify and announce the purpose of each input field.

📸 **Before/After:** The visual appearance remains identical (maintained using `display: "block"` and `fontWeight: "bold"`), but the underlying markup is now semantically correct.

♿ **Accessibility:** Form controls (Frecuencia, Geometría, and Duración) are now properly associated with descriptive labels, significantly improving usability for users relying on screen readers.

---
*PR created automatically by Jules for task [7667696645146014005](https://jules.google.com/task/7667696645146014005) started by @mexicodxnmexico-create*