### PR TITLE
⚡ Bolt: Use throttled useRef in useFrame to prevent R3F re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,6 @@
 ## 2025-06-24 - Efficient Fixed-Size Array Updates
 **Learning:** Using `[...arr, item].slice(-N)` for maintaining a fixed-size buffer causes two array allocations (one for the spread and one for the final slice). While `shift()` is O(n), using `slice()` followed by `push()` and `shift()` is significantly faster because it minimizes heap pressure by avoiding the intermediate array allocation.
 **Action:** Prefer `slice()` + `push()` + `shift()` for more efficient memory management in state transitions.
+## 2025-06-25 - React Three Fiber Re-render Storm via Parent State
+**Learning:** Found that a React state `setInterval` updating `intensidad` every 2 seconds in the parent `EscenaMeditacion3D` was causing the entire R3F `<Canvas>` and all its complex 3D children to reconcile unnecessarily.
+**Action:** Replicated the throttled interval logic entirely inside the `useFrame` loop of the child `GeometriaSagrada3D` using mutable `useRef` (e.g., `lastUpdateTimeRef` and `intensidadRef`). This offloads the high-frequency updates to the native WebGL render loop, bypassing React state entirely and ensuring O(1) performance for visual animations.

--- a/components/3d/EscenaMeditacion3D.tsx
+++ b/components/3d/EscenaMeditacion3D.tsx
@@ -2,7 +2,7 @@
 
 import { Canvas } from "@react-three/fiber";
 import { OrbitControls, Stars, Environment } from "@react-three/drei";
-import { Suspense, useState, useEffect, memo } from "react";
+import { Suspense, memo } from "react";
 import { GeometriaSagrada3D } from "./GeometriaSagrada3D";
 import { ParticulasCuanticas } from "./ParticulasCuanticas";
 
@@ -14,21 +14,6 @@ interface EscenaMeditacion3DProps {
 
 // ⚡ BOLT: Wrap in React.memo to prevent massive 3D canvas re-renders caused by parent 1-second timers
 export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia, activo, tipoGeometria }: EscenaMeditacion3DProps) {
-  const [intensidad, setIntensidad] = useState(50);
-
-  useEffect(() => {
-    if (!activo) return;
-
-    const intervalo = setInterval(() => {
-      setIntensidad(prev => {
-        const nuevo = prev + (Math.random() - 0.5) * 10;
-        return Math.max(30, Math.min(70, nuevo));
-      });
-    }, 2000);
-
-    return () => clearInterval(intervalo);
-  }, [activo]);
-
   return (
     <div style={{ width: "100%", height: "600px", borderRadius: "20px", overflow: "hidden" }}>
       <Canvas
@@ -55,7 +40,7 @@ export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia,
 
           <GeometriaSagrada3D
             frecuencia={frecuencia}
-            intensidad={intensidad}
+            activo={activo}
             tipo={tipoGeometria}
           />
 

--- a/components/3d/GeometriaSagrada3D.tsx
+++ b/components/3d/GeometriaSagrada3D.tsx
@@ -6,13 +6,15 @@ import * as THREE from "three";
 
 interface GeometriaSagrada3DProps {
   frecuencia: number;
-  intensidad: number;
+  activo: boolean;
   tipo: "flor-vida" | "merkaba" | "metatron" | "torus";
 }
 
-export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSagrada3DProps) {
+export function GeometriaSagrada3D({ frecuencia, activo, tipo }: GeometriaSagrada3DProps) {
   const grupoRef = useRef<THREE.Group>(null);
   const tiempo = useRef(0);
+  const lastUpdateTimeRef = useRef(0);
+  const intensidadRef = useRef(50);
 
   // ⚡ OPTIMIZACIÓN: Calcular color basado en frecuencia solo cuando cambia
   const colorFrecuencia = useMemo(() => {
@@ -64,8 +66,7 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
   useEffect(() => {
     material.color.set(colorFrecuencia);
     material.emissive.set(colorFrecuencia);
-    material.emissiveIntensity = intensidad / 100;
-  }, [material, colorFrecuencia, intensidad]);
+  }, [material, colorFrecuencia]);
 
   useEffect(() => {
     return () => material.dispose();
@@ -77,13 +78,23 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
 
     tiempo.current += delta;
 
+    // ⚡ BOLT OPTIMIZATION: Replicate the 2-second interval logic here
+    // avoiding React state updates which cause full re-renders of the 3D scene.
+    if (activo && tiempo.current - lastUpdateTimeRef.current >= 2) {
+      lastUpdateTimeRef.current = tiempo.current;
+      const nuevo = intensidadRef.current + (Math.random() - 0.5) * 10;
+      intensidadRef.current = Math.max(30, Math.min(70, nuevo));
+    }
+
+    material.emissiveIntensity = intensidadRef.current / 100;
+
     // Rotación suave basada en la frecuencia
     const velocidad = frecuencia / 10000;
     grupoRef.current.rotation.y += velocidad;
     grupoRef.current.rotation.x = Math.sin(tiempo.current * 0.3) * 0.2;
 
     // Pulsación basada en intensidad
-    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidad / 200);
+    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidadRef.current / 200);
     grupoRef.current.scale.setScalar(escala);
   });
 


### PR DESCRIPTION
💡 **What:** 
Moved the 2-second intensity update logic from a React `useState` interval in the parent `EscenaMeditacion3D` down into the `useFrame` loop of `GeometriaSagrada3D` using a throttled `useRef` pattern.

🎯 **Why:** 
Previously, the `setInterval` caused a full React state update every 2 seconds. In a React Three Fiber context, updating parent state forces reconciliation of the entire `<Canvas>` and all its complex 3D children, creating a severe rendering bottleneck.

📊 **Impact:** 
Eliminates full React reconciliations of the 3D scene every 2 seconds. The animation logic is now handled entirely within the native WebGL render loop (O(1) update cost), significantly reducing main-thread blockage and CPU usage during meditation sessions.

🔬 **Measurement:** 
Verify that the geometry still pulses/changes intensity every 2 seconds. You can measure the improvement by opening the React Profiler or Chrome Performance tab while the 3D scene is active and observing the absence of large React commit/reconciliation spikes every 2 seconds.

---
*PR created automatically by Jules for task [16652475679090732701](https://jules.google.com/task/16652475679090732701) started by @mexicodxnmexico-create*