### PR TITLE
🧪 Add fractional beta rounding tests for QuantumMirror

### DIFF
--- a/tests/quantum-mirror.test.tsx
+++ b/tests/quantum-mirror.test.tsx
@@ -139,6 +139,55 @@ test('QuantumMirror deviceorientation logic', async (t) => {
     });
   });
 
+  await t.test('handles fractional beta values correctly', () => {
+    let root: TestRenderer.ReactTestRenderer | undefined;
+
+    TestRenderer.act(() => {
+      root = TestRenderer.create(<QuantumMirror />);
+    });
+
+    // Beta 14 -> 1.4 -> round(1.4) = 1. Frequency = 432 + 1 = 433
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 0, beta: 14, gamma: 0 });
+        });
+      }
+    });
+
+    const freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+    assert.strictEqual(freqDiv.children[0], '433');
+
+    // Beta 16 -> 1.6 -> round(1.6) = 2. Frequency = 432 + 2 = 434
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 0, beta: 16, gamma: 0 });
+        });
+      }
+    });
+
+    assert.strictEqual(freqDiv.children[0], '434');
+
+    // Beta 15 -> 1.5 -> round(1.5) = 2. Frequency = 432 + 2 = 434
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 0, beta: 15, gamma: 0 });
+        });
+      }
+    });
+
+    assert.strictEqual(freqDiv.children[0], '434');
+
+    TestRenderer.act(() => {
+      root!.unmount();
+    });
+  });
+
   await t.test('handles missing event values gracefully', () => {
     let root: TestRenderer.ReactTestRenderer | undefined;
 


### PR DESCRIPTION
🎯 **What:** Added a new test case to `tests/quantum-mirror.test.tsx` to verify the mathematical rounding logic tied to the `beta` sensor value (`Math.round(e.beta / 10)`).

📊 **Coverage:** The new test specifically dispatches mocked boundary fractional `beta` values (`14`, `15`, `16`) that confirm whether the deviceorientation handler dynamically rounds down to `1` or up to `2` successfully, expanding the coverage for the event handler.

✨ **Result:** Improved test reliability and deterministic coverage for the `deviceorientation` mathematical translation, mitigating regressions in future refactors involving physical device sensor data logic.

---
*PR created automatically by Jules for task [4452080076834278264](https://jules.google.com/task/4452080076834278264) started by @mexicodxnmexico-create*