### PR TITLE
⚡ Bolt: Eliminate 3D canvas re-renders by moving state to refs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,6 @@
 ## 2025-06-24 - Efficient Fixed-Size Array Updates
 **Learning:** Using `[...arr, item].slice(-N)` for maintaining a fixed-size buffer causes two array allocations (one for the spread and one for the final slice). While `shift()` is O(n), using `slice()` followed by `push()` and `shift()` is significantly faster because it minimizes heap pressure by avoiding the intermediate array allocation.
 **Action:** Prefer `slice()` + `push()` + `shift()` for more efficient memory management in state transitions.
+## 2025-06-25 - React Three Fiber Frame Ref Optimization
+**Learning:** Found that using React `useState` combined with a `setInterval` to drive animations or timed updates (e.g., oscillating intensity) in a parent component (like `EscenaMeditacion3D`) forces full React tree reconciliation every tick, severely impacting 3D performance in `<Canvas>`.
+**Action:** When implementing timed visual updates in React Three Fiber, pass a static boolean (like `activo`) to the child component and move the interval logic into `useFrame`. Use `useRef` to track elapsed time (`tiempo.current - lastUpdateRef.current`) and state values (`intensidadRef`), and mutate the underlying Three.js material directly to completely bypass React's render cycle for O(1) performance.

--- a/components/3d/EscenaMeditacion3D.tsx
+++ b/components/3d/EscenaMeditacion3D.tsx
@@ -2,7 +2,7 @@
 
 import { Canvas } from "@react-three/fiber";
 import { OrbitControls, Stars, Environment } from "@react-three/drei";
-import { Suspense, useState, useEffect, memo } from "react";
+import { Suspense, memo } from "react";
 import { GeometriaSagrada3D } from "./GeometriaSagrada3D";
 import { ParticulasCuanticas } from "./ParticulasCuanticas";
 
@@ -14,20 +14,6 @@ interface EscenaMeditacion3DProps {
 
 // ⚡ BOLT: Wrap in React.memo to prevent massive 3D canvas re-renders caused by parent 1-second timers
 export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia, activo, tipoGeometria }: EscenaMeditacion3DProps) {
-  const [intensidad, setIntensidad] = useState(50);
-
-  useEffect(() => {
-    if (!activo) return;
-
-    const intervalo = setInterval(() => {
-      setIntensidad(prev => {
-        const nuevo = prev + (Math.random() - 0.5) * 10;
-        return Math.max(30, Math.min(70, nuevo));
-      });
-    }, 2000);
-
-    return () => clearInterval(intervalo);
-  }, [activo]);
 
   return (
     <div style={{ width: "100%", height: "600px", borderRadius: "20px", overflow: "hidden" }}>
@@ -55,7 +41,7 @@ export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia,
 
           <GeometriaSagrada3D
             frecuencia={frecuencia}
-            intensidad={intensidad}
+            activo={activo}
             tipo={tipoGeometria}
           />
 

--- a/components/3d/GeometriaSagrada3D.tsx
+++ b/components/3d/GeometriaSagrada3D.tsx
@@ -6,13 +6,17 @@ import * as THREE from "three";
 
 interface GeometriaSagrada3DProps {
   frecuencia: number;
-  intensidad: number;
+  activo: boolean;
   tipo: "flor-vida" | "merkaba" | "metatron" | "torus";
 }
 
-export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSagrada3DProps) {
+export function GeometriaSagrada3D({ frecuencia, activo, tipo }: GeometriaSagrada3DProps) {
   const grupoRef = useRef<THREE.Group>(null);
   const tiempo = useRef(0);
+
+  // ⚡ BOLT: Move intensity state to refs to prevent React reconciliation during high-frequency updates
+  const intensidadRef = useRef(50);
+  const lastUpdateRef = useRef(0);
 
   // ⚡ OPTIMIZACIÓN: Calcular color basado en frecuencia solo cuando cambia
   const colorFrecuencia = useMemo(() => {
@@ -64,8 +68,8 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
   useEffect(() => {
     material.color.set(colorFrecuencia);
     material.emissive.set(colorFrecuencia);
-    material.emissiveIntensity = intensidad / 100;
-  }, [material, colorFrecuencia, intensidad]);
+    // emissiveIntensity is now managed in useFrame
+  }, [material, colorFrecuencia]);
 
   useEffect(() => {
     return () => material.dispose();
@@ -77,14 +81,24 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
 
     tiempo.current += delta;
 
+    // ⚡ BOLT: Simulate 2s interval logic inside the render loop using refs
+    if (activo && tiempo.current - lastUpdateRef.current > 2) {
+      const nuevo = intensidadRef.current + (Math.random() - 0.5) * 10;
+      intensidadRef.current = Math.max(30, Math.min(70, nuevo));
+      lastUpdateRef.current = tiempo.current;
+    }
+
     // Rotación suave basada en la frecuencia
     const velocidad = frecuencia / 10000;
     grupoRef.current.rotation.y += velocidad;
     grupoRef.current.rotation.x = Math.sin(tiempo.current * 0.3) * 0.2;
 
     // Pulsación basada en intensidad
-    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidad / 200);
+    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidadRef.current / 200);
     grupoRef.current.scale.setScalar(escala);
+
+    // ⚡ BOLT: Directly mutate material to avoid React state
+    material.emissiveIntensity = intensidadRef.current / 100;
   });
 
   return (


### PR DESCRIPTION
💡 What: Moved high-frequency intensity oscillation state from `useState` and `setInterval` in `EscenaMeditacion3D` to `useRef` and time-delta checks within `GeometriaSagrada3D`'s `useFrame` loop.
🎯 Why: The previous `setInterval` caused React state updates every 2 seconds in the parent, forcing React to reconcile the entire `<Canvas>` and its 3D children, which is an expensive anti-pattern for WebGL components.
📊 Impact: Completely eliminates React tree reconciliation for the 3D scene while active, changing DOM updates from O(n) to O(1) inside the WebGL context.
🔬 Measurement: Observe that the component only re-renders when meditation starts/stops or frequency changes, instead of every 2 seconds. Use React DevTools Profiler to confirm zero re-renders of `EscenaMeditacion3D` during active meditation.

---
*PR created automatically by Jules for task [4416781087334474441](https://jules.google.com/task/4416781087334474441) started by @mexicodxnmexico-create*