### PR TITLE
⚡ Bolt: Optimize R3F rendering by moving intensity oscillation to refs

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,7 +27,7 @@ const H1_STYLE: CSSProperties = { fontSize: "3.5rem", marginBottom: "1rem", lett
 const STATUS_STYLE: CSSProperties = { fontSize: "1.25rem", color: "#666", maxWidth: "600px", margin: "0 auto" };
 const FOOTER_STYLE: CSSProperties = { padding: "4rem 0", textAlign: "center", borderTop: "1px solid #eaeaea", color: "#555", fontSize: "0.8rem" };
 const TABS_STYLE: CSSProperties = { display: "flex", justifyContent: "center", gap: "1rem", marginBottom: "2rem" };
-const TAB_BUTTON_STYLE: CSSProperties = { padding: "0.5rem 1rem", border: "1px solid #ccc", borderRadius: "4px", background: "none", cursor: "pointer", fontSize: "1rem" };
+const TAB_BUTTON_STYLE: CSSProperties = { padding: "0.5rem 1rem", borderStyle: "solid", borderWidth: "1px", borderColor: "#ccc", borderRadius: "4px", background: "none", cursor: "pointer", fontSize: "1rem" };
 const TAB_BUTTON_ACTIVE_STYLE: CSSProperties = { ...TAB_BUTTON_STYLE, background: "#000", color: "#fff", borderColor: "#000" };
 
 export default function Home() {

--- a/components/3d/EscenaMeditacion3D.tsx
+++ b/components/3d/EscenaMeditacion3D.tsx
@@ -2,7 +2,7 @@
 
 import { Canvas } from "@react-three/fiber";
 import { OrbitControls, Stars, Environment } from "@react-three/drei";
-import { Suspense, useState, useEffect, memo } from "react";
+import { Suspense, memo } from "react";
 import { GeometriaSagrada3D } from "./GeometriaSagrada3D";
 import { ParticulasCuanticas } from "./ParticulasCuanticas";
 
@@ -14,21 +14,6 @@ interface EscenaMeditacion3DProps {
 
 // ⚡ BOLT: Wrap in React.memo to prevent massive 3D canvas re-renders caused by parent 1-second timers
 export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia, activo, tipoGeometria }: EscenaMeditacion3DProps) {
-  const [intensidad, setIntensidad] = useState(50);
-
-  useEffect(() => {
-    if (!activo) return;
-
-    const intervalo = setInterval(() => {
-      setIntensidad(prev => {
-        const nuevo = prev + (Math.random() - 0.5) * 10;
-        return Math.max(30, Math.min(70, nuevo));
-      });
-    }, 2000);
-
-    return () => clearInterval(intervalo);
-  }, [activo]);
-
   return (
     <div style={{ width: "100%", height: "600px", borderRadius: "20px", overflow: "hidden" }}>
       <Canvas
@@ -55,7 +40,7 @@ export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia,
 
           <GeometriaSagrada3D
             frecuencia={frecuencia}
-            intensidad={intensidad}
+            activo={activo}
             tipo={tipoGeometria}
           />
 

--- a/components/3d/GeometriaSagrada3D.tsx
+++ b/components/3d/GeometriaSagrada3D.tsx
@@ -1,18 +1,20 @@
 "use client";
 
-import { useRef, useMemo, useEffect } from "react";
+import { useRef, useMemo, useEffect, memo } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
 interface GeometriaSagrada3DProps {
   frecuencia: number;
-  intensidad: number;
+  activo: boolean;
   tipo: "flor-vida" | "merkaba" | "metatron" | "torus";
 }
 
-export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSagrada3DProps) {
+export const GeometriaSagrada3D = memo(function GeometriaSagrada3D({ frecuencia, activo, tipo }: GeometriaSagrada3DProps) {
   const grupoRef = useRef<THREE.Group>(null);
   const tiempo = useRef(0);
+  const intensidadRef = useRef(50);
+  const lastIntensityUpdateRef = useRef(0);
 
   // ⚡ OPTIMIZACIÓN: Calcular color basado en frecuencia solo cuando cambia
   const colorFrecuencia = useMemo(() => {
@@ -64,26 +66,35 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
   useEffect(() => {
     material.color.set(colorFrecuencia);
     material.emissive.set(colorFrecuencia);
-    material.emissiveIntensity = intensidad / 100;
-  }, [material, colorFrecuencia, intensidad]);
+    // Initial value
+    material.emissiveIntensity = intensidadRef.current / 100;
+  }, [material, colorFrecuencia]);
 
   useEffect(() => {
     return () => material.dispose();
   }, [material]);
 
   // Animación continua
-  useFrame((_state, delta) => {
+  useFrame((state) => {
     if (!grupoRef.current) return;
 
-    tiempo.current += delta;
+    const t = state.clock.getElapsedTime();
+    tiempo.current = t;
+
+    // ⚡ BOLT: Handle intensity oscillation in the loop to avoid React re-renders
+    if (activo && t - lastIntensityUpdateRef.current > 2) {
+      intensidadRef.current = Math.max(30, Math.min(70, intensidadRef.current + (Math.random() - 0.5) * 10));
+      lastIntensityUpdateRef.current = t;
+      material.emissiveIntensity = intensidadRef.current / 100;
+    }
 
     // Rotación suave basada en la frecuencia
     const velocidad = frecuencia / 10000;
     grupoRef.current.rotation.y += velocidad;
-    grupoRef.current.rotation.x = Math.sin(tiempo.current * 0.3) * 0.2;
+    grupoRef.current.rotation.x = Math.sin(t * 0.3) * 0.2;
 
     // Pulsación basada en intensidad
-    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidad / 200);
+    const escala = 1 + Math.sin(t * 2) * (intensidadRef.current / 200);
     grupoRef.current.scale.setScalar(escala);
   });
 
@@ -94,7 +105,7 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
       ))}
     </group>
   );
-}
+});
 
 interface GeoData {
   geometria: THREE.BufferGeometry;

--- a/components/3d/ParticulasCuanticas.tsx
+++ b/components/3d/ParticulasCuanticas.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useMemo } from "react";
+import { useRef, useMemo, memo } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
@@ -19,7 +19,7 @@ const COLORES_SOLFEGGIO: Record<number, { r: number; g: number; b: number }> = {
   852: { r: 0.51, g: 0.22, b: 0.93 }
 };
 
-export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuanticasProps) {
+export const ParticulasCuanticas = memo(function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuanticasProps) {
   const particulasRef = useRef<THREE.Points>(null);
   const tiempo = useRef(0);
 
@@ -128,4 +128,4 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
       />
     </points>
   );
-}
+});

--- a/components/HistorySection.tsx
+++ b/components/HistorySection.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, memo, useMemo } from "react";
+import { CSSProperties, memo } from "react";
 
 const HISTORY_SECTION_STYLE: CSSProperties = { marginBottom: "1.5rem" };
 const LOG_CONTAINER_STYLE: CSSProperties = {


### PR DESCRIPTION
💡 What:
- Moved the intensity oscillation logic from `EscenaMeditacion3D` state to `GeometriaSagrada3D`'s `useFrame` loop using `useRef`.
- Wrapped `GeometriaSagrada3D`, `EscenaMeditacion3D`, and `ParticulasCuanticas` in `React.memo`.
- Removed high-frequency `setInterval` (2s) that was triggering React re-renders for the entire 3D scene.
- Fixed a style hydration issue in `app/page.tsx` by splitting shorthand `border` into individual properties.
- Cleaned up unused imports to satisfy strict build requirements.

🎯 Why:
- Updating React state at high frequencies (especially within a 3D scene) triggers expensive reconciliation and re-renders of the entire component tree, including the Three.js Canvas.
- Direct mutation of Three.js properties (like `emissiveIntensity` and `scale`) inside the `useFrame` loop is significantly more efficient as it bypasses React entirely for visual-only updates.

📊 Impact:
- Reduces React re-renders during meditation by 100% (previously 1 re-render every 2 seconds).
- Decreases CPU usage and memory pressure by avoiding redundant DOM/VDOM operations and object allocations.
- Ensures smoother animations by keeping the main thread free from React reconciliation tasks during the 3D rendering loop.

🔬 Measurement:
- Verify that `GeometriaSagrada3D` does not re-render (e.g., using React DevTools profiler) when the intensity oscillates during meditation.
- Confirm production build success (`pnpm build`).
- Run the full test suite (`npx tsx --test tests/*.test.ts tests/*.test.tsx`).

---
*PR created automatically by Jules for task [9215702468435237961](https://jules.google.com/task/9215702468435237961) started by @mexicodxnmexico-create*