### PR TITLE
⚡ Bolt: Optimize 3D meditation scene performance

### DIFF
--- a/components/3d/EscenaMeditacion3D.tsx
+++ b/components/3d/EscenaMeditacion3D.tsx
@@ -2,7 +2,7 @@
 
 import { Canvas } from "@react-three/fiber";
 import { OrbitControls, Stars, Environment } from "@react-three/drei";
-import { Suspense, useState, useEffect, memo } from "react";
+import { Suspense, memo } from "react";
 import { GeometriaSagrada3D } from "./GeometriaSagrada3D";
 import { ParticulasCuanticas } from "./ParticulasCuanticas";
 
@@ -14,20 +14,9 @@ interface EscenaMeditacion3DProps {
 
 // ⚡ BOLT: Wrap in React.memo to prevent massive 3D canvas re-renders caused by parent 1-second timers
 export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia, activo, tipoGeometria }: EscenaMeditacion3DProps) {
-  const [intensidad, setIntensidad] = useState(50);
-
-  useEffect(() => {
-    if (!activo) return;
-
-    const intervalo = setInterval(() => {
-      setIntensidad(prev => {
-        const nuevo = prev + (Math.random() - 0.5) * 10;
-        return Math.max(30, Math.min(70, nuevo));
-      });
-    }, 2000);
-
-    return () => clearInterval(intervalo);
-  }, [activo]);
+  // ⚡ BOLT OPTIMIZATION: Removed 'intensidad' state and its associated useEffect.
+  // The intensity oscillation is now handled via refs inside GeometriaSagrada3D
+  // using the useFrame loop, eliminating React re-renders for this purely visual effect.
 
   return (
     <div style={{ width: "100%", height: "600px", borderRadius: "20px", overflow: "hidden" }}>
@@ -55,7 +44,7 @@ export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia,
 
           <GeometriaSagrada3D
             frecuencia={frecuencia}
-            intensidad={intensidad}
+            activo={activo}
             tipo={tipoGeometria}
           />
 

--- a/components/3d/GeometriaSagrada3D.tsx
+++ b/components/3d/GeometriaSagrada3D.tsx
@@ -1,18 +1,20 @@
 "use client";
 
-import { useRef, useMemo, useEffect } from "react";
+import { useRef, useMemo, useEffect, memo } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
 interface GeometriaSagrada3DProps {
   frecuencia: number;
-  intensidad: number;
+  activo: boolean;
   tipo: "flor-vida" | "merkaba" | "metatron" | "torus";
 }
 
-export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSagrada3DProps) {
+export const GeometriaSagrada3D = memo(function GeometriaSagrada3D({ frecuencia, activo, tipo }: GeometriaSagrada3DProps) {
   const grupoRef = useRef<THREE.Group>(null);
   const tiempo = useRef(0);
+  const intensidadRef = useRef(50);
+  const lastUpdateRef = useRef(0);
 
   // ⚡ OPTIMIZACIÓN: Calcular color basado en frecuencia solo cuando cambia
   const colorFrecuencia = useMemo(() => {
@@ -64,26 +66,36 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
   useEffect(() => {
     material.color.set(colorFrecuencia);
     material.emissive.set(colorFrecuencia);
-    material.emissiveIntensity = intensidad / 100;
-  }, [material, colorFrecuencia, intensidad]);
+    // ⚡ BOLT: Initial intensity setup, then managed via ref in useFrame
+    material.emissiveIntensity = intensidadRef.current / 100;
+  }, [material, colorFrecuencia]);
 
   useEffect(() => {
     return () => material.dispose();
   }, [material]);
 
   // Animación continua
-  useFrame((_state, delta) => {
+  useFrame((state, delta) => {
     if (!grupoRef.current) return;
 
     tiempo.current += delta;
+    const t = tiempo.current;
+
+    // ⚡ BOLT OPTIMIZATION: Throttled intensity update using refs to skip React reconciliation.
+    // Replaces the 2-second interval in the parent component.
+    if (activo && state.clock.elapsedTime - lastUpdateRef.current > 2) {
+      intensidadRef.current = Math.max(30, Math.min(70, intensidadRef.current + (Math.random() - 0.5) * 10));
+      material.emissiveIntensity = intensidadRef.current / 100;
+      lastUpdateRef.current = state.clock.elapsedTime;
+    }
 
     // Rotación suave basada en la frecuencia
     const velocidad = frecuencia / 10000;
     grupoRef.current.rotation.y += velocidad;
-    grupoRef.current.rotation.x = Math.sin(tiempo.current * 0.3) * 0.2;
+    grupoRef.current.rotation.x = Math.sin(t * 0.3) * 0.2;
 
-    // Pulsación basada en intensidad
-    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidad / 200);
+    // Pulsación basada en intensidad (direct mutation via ref)
+    const escala = 1 + Math.sin(t * 2) * (intensidadRef.current / 200);
     grupoRef.current.scale.setScalar(escala);
   });
 
@@ -94,7 +106,7 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
       ))}
     </group>
   );
-}
+});
 
 interface GeoData {
   geometria: THREE.BufferGeometry;

--- a/components/3d/ParticulasCuanticas.tsx
+++ b/components/3d/ParticulasCuanticas.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useMemo } from "react";
+import { useRef, useMemo, memo } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
@@ -19,7 +19,7 @@ const COLORES_SOLFEGGIO: Record<number, { r: number; g: number; b: number }> = {
   852: { r: 0.51, g: 0.22, b: 0.93 }
 };
 
-export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuanticasProps) {
+export const ParticulasCuanticas = memo(function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuanticasProps) {
   const particulasRef = useRef<THREE.Points>(null);
   const tiempo = useRef(0);
 
@@ -128,4 +128,4 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
       />
     </points>
   );
-}
+});

--- a/components/HistorySection.tsx
+++ b/components/HistorySection.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, memo, useMemo } from "react";
+import { CSSProperties, memo } from "react";
 
 const HISTORY_SECTION_STYLE: CSSProperties = { marginBottom: "1.5rem" };
 const LOG_CONTAINER_STYLE: CSSProperties = {


### PR DESCRIPTION
💡 What:
- Moved the `intensidad` (intensity) oscillation logic from a React `useState` and `useEffect` in `EscenaMeditacion3D` to a `useRef` and the `useFrame` loop in `GeometriaSagrada3D`.
- Wrapped `EscenaMeditacion3D`, `GeometriaSagrada3D`, and `ParticulasCuanticas` in `React.memo`.
- Removed redundant `useMemo` from `HistorySection.tsx` which was causing a linting warning/type error.

🎯 Why:
- Using React state to drive high-frequency visual oscillations (every 2 seconds) causes the entire 3D scene (Canvas and all children) to undergo React reconciliation and re-rendering.
- In React Three Fiber, visual updates that don't affect React state should be handled directly in the render loop for maximum performance and smoother animations.

📊 Impact:
- Reduces React re-renders of the 3D scene by 100% during active meditation (excluding the initial mount and prop changes).
- Eliminates the overhead of React's diffing and reconciliation for purely visual animations.

🔬 Measurement:
- Verify that the 3D scene still oscillates in intensity during meditation.
- Use React DevTools Profiler to confirm that `EscenaMeditacion3D` and its children no longer re-render every 2 seconds when meditation is active.

---
*PR created automatically by Jules for task [18362784928835632843](https://jules.google.com/task/18362784928835632843) started by @mexicodxnmexico-create*