### PR TITLE
🧪 [test] add fractional and undefined beta tests to QuantumMirror

### DIFF
--- a/tests/quantum-mirror.test.tsx
+++ b/tests/quantum-mirror.test.tsx
@@ -52,6 +52,21 @@ test('QuantumMirror deviceorientation logic', async (t) => {
     assert.strictEqual(betaDiv.children[0], '0');
     assert.strictEqual(gammaDiv.children[0], '0');
 
+    // Dispatch mock deviceorientation event with undefined values
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: undefined, beta: undefined, gamma: undefined });
+        });
+      }
+    });
+
+    assert.strictEqual(freqDiv.children[0], '432');
+    assert.strictEqual(alphaDiv.children[0], '0');
+    assert.strictEqual(betaDiv.children[0], '0');
+    assert.strictEqual(gammaDiv.children[0], '0');
+
     TestRenderer.act(() => {
       root!.unmount();
     });
@@ -132,6 +147,55 @@ test('QuantumMirror deviceorientation logic', async (t) => {
     assert.strictEqual(freqDiv.children[0], '432');
     assert.strictEqual(alphaDiv.children[0], '20');
     assert.strictEqual(betaDiv.children[0], '0');
+    assert.strictEqual(gammaDiv.children[0], '20');
+
+    TestRenderer.act(() => {
+      root!.unmount();
+    });
+  });
+
+  await t.test('handles fractional beta values correctly with rounding', () => {
+    let root: TestRenderer.ReactTestRenderer | undefined;
+
+    TestRenderer.act(() => {
+      root = TestRenderer.create(<QuantumMirror />);
+    });
+
+    // Test rounding down
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 10, beta: 44.9, gamma: 10 });
+        });
+      }
+    });
+
+    const freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+    const alphaDiv = root!.root.findByProps({ 'data-testid': 'rotation-alpha' });
+    const betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
+    const gammaDiv = root!.root.findByProps({ 'data-testid': 'rotation-gamma' });
+
+    // 432 + Math.round(44.9 / 10) = 432 + Math.round(4.49) = 432 + 4 = 436
+    assert.strictEqual(freqDiv.children[0], '436');
+    assert.strictEqual(alphaDiv.children[0], '10');
+    assert.strictEqual(betaDiv.children[0], '44.9');
+    assert.strictEqual(gammaDiv.children[0], '10');
+
+    // Test rounding up
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 20, beta: 45.1, gamma: 20 });
+        });
+      }
+    });
+
+    // 432 + Math.round(45.1 / 10) = 432 + Math.round(4.51) = 432 + 5 = 437
+    assert.strictEqual(freqDiv.children[0], '437');
+    assert.strictEqual(alphaDiv.children[0], '20');
+    assert.strictEqual(betaDiv.children[0], '45.1');
     assert.strictEqual(gammaDiv.children[0], '20');
 
     TestRenderer.act(() => {


### PR DESCRIPTION
🎯 **What:** The testing gap addressed involves missing edge-case assertions for the `deviceorientation` event handling within the `QuantumMirror` component. Specifically, fractional values for orientation properties and the scenario where event properties could be missing or undefined needed test coverage to ensure the application logic behaves deterministically.

📊 **Coverage:** Scenarios now tested include:
- A mocked dispatch of `deviceorientation` with fractional values (`beta: 44.9` and `beta: 45.1`), verifying that the resulting state frequency properly applies the `Math.round(beta / 10)` formula up and down.
- A mocked dispatch of `deviceorientation` with `undefined` values (`{ alpha: undefined, beta: undefined, gamma: undefined }`), asserting that the component safely and properly falls back to `0` state properties as expected.

✨ **Result:** Test coverage for `src/components/QuantumMirror.tsx` and the `tests/quantum-mirror.test.tsx` suite improves with 6 total assertions covering fractional rounding boundaries and runtime fallback defaults. All regression tests continue to pass.

---
*PR created automatically by Jules for task [4174611962757716167](https://jules.google.com/task/4174611962757716167) started by @mexicodxnmexico-create*