### PR TITLE
⚡ Bolt: Optimize 3D scene re-renders and particle loop performance

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,8 +27,22 @@ const H1_STYLE: CSSProperties = { fontSize: "3.5rem", marginBottom: "1rem", lett
 const STATUS_STYLE: CSSProperties = { fontSize: "1.25rem", color: "#666", maxWidth: "600px", margin: "0 auto" };
 const FOOTER_STYLE: CSSProperties = { padding: "4rem 0", textAlign: "center", borderTop: "1px solid #eaeaea", color: "#555", fontSize: "0.8rem" };
 const TABS_STYLE: CSSProperties = { display: "flex", justifyContent: "center", gap: "1rem", marginBottom: "2rem" };
-const TAB_BUTTON_STYLE: CSSProperties = { padding: "0.5rem 1rem", border: "1px solid #ccc", borderRadius: "4px", background: "none", cursor: "pointer", fontSize: "1rem" };
-const TAB_BUTTON_ACTIVE_STYLE: CSSProperties = { ...TAB_BUTTON_STYLE, background: "#000", color: "#fff", borderColor: "#000" };
+const TAB_BUTTON_STYLE: CSSProperties = {
+  padding: "0.5rem 1rem",
+  borderWidth: "1px",
+  borderStyle: "solid",
+  borderColor: "#ccc",
+  borderRadius: "4px",
+  background: "none",
+  cursor: "pointer",
+  fontSize: "1rem"
+};
+const TAB_BUTTON_ACTIVE_STYLE: CSSProperties = {
+  ...TAB_BUTTON_STYLE,
+  background: "#000",
+  color: "#fff",
+  borderColor: "#000"
+};
 
 export default function Home() {
   const { state, loading, dispatch } = useQuantum();

--- a/components/3d/EscenaMeditacion3D.tsx
+++ b/components/3d/EscenaMeditacion3D.tsx
@@ -2,7 +2,7 @@
 
 import { Canvas } from "@react-three/fiber";
 import { OrbitControls, Stars, Environment } from "@react-three/drei";
-import { Suspense, useState, useEffect, memo } from "react";
+import { Suspense, memo } from "react";
 import { GeometriaSagrada3D } from "./GeometriaSagrada3D";
 import { ParticulasCuanticas } from "./ParticulasCuanticas";
 
@@ -14,21 +14,6 @@ interface EscenaMeditacion3DProps {
 
 // ⚡ BOLT: Wrap in React.memo to prevent massive 3D canvas re-renders caused by parent 1-second timers
 export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia, activo, tipoGeometria }: EscenaMeditacion3DProps) {
-  const [intensidad, setIntensidad] = useState(50);
-
-  useEffect(() => {
-    if (!activo) return;
-
-    const intervalo = setInterval(() => {
-      setIntensidad(prev => {
-        const nuevo = prev + (Math.random() - 0.5) * 10;
-        return Math.max(30, Math.min(70, nuevo));
-      });
-    }, 2000);
-
-    return () => clearInterval(intervalo);
-  }, [activo]);
-
   return (
     <div style={{ width: "100%", height: "600px", borderRadius: "20px", overflow: "hidden" }}>
       <Canvas
@@ -55,7 +40,7 @@ export const EscenaMeditacion3D = memo(function EscenaMeditacion3D({ frecuencia,
 
           <GeometriaSagrada3D
             frecuencia={frecuencia}
-            intensidad={intensidad}
+            activo={activo}
             tipo={tipoGeometria}
           />
 

--- a/components/3d/GeometriaSagrada3D.tsx
+++ b/components/3d/GeometriaSagrada3D.tsx
@@ -1,18 +1,22 @@
 "use client";
 
-import { useRef, useMemo, useEffect } from "react";
+import { useRef, useMemo, useEffect, memo } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
 interface GeometriaSagrada3DProps {
   frecuencia: number;
-  intensidad: number;
+  activo: boolean;
   tipo: "flor-vida" | "merkaba" | "metatron" | "torus";
 }
 
-export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSagrada3DProps) {
+// ⚡ BOLT: Wrap in React.memo to skip reconciliation when parents (like the meditation timer) update.
+// Visual updates are handled internally via refs and useFrame for maximum performance.
+export const GeometriaSagrada3D = memo(function GeometriaSagrada3D({ frecuencia, activo, tipo }: GeometriaSagrada3DProps) {
   const grupoRef = useRef<THREE.Group>(null);
   const tiempo = useRef(0);
+  const intensidadRef = useRef(50);
+  const lastIntensityUpdateRef = useRef(0);
 
   // ⚡ OPTIMIZACIÓN: Calcular color basado en frecuencia solo cuando cambia
   const colorFrecuencia = useMemo(() => {
@@ -64,26 +68,38 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
   useEffect(() => {
     material.color.set(colorFrecuencia);
     material.emissive.set(colorFrecuencia);
-    material.emissiveIntensity = intensidad / 100;
-  }, [material, colorFrecuencia, intensidad]);
+    material.emissiveIntensity = intensidadRef.current / 100;
+  }, [material, colorFrecuencia]);
 
   useEffect(() => {
     return () => material.dispose();
   }, [material]);
 
   // Animación continua
-  useFrame((_state, delta) => {
+  useFrame((state) => {
     if (!grupoRef.current) return;
 
-    tiempo.current += delta;
+    const t = state.clock.elapsedTime;
+    tiempo.current = t;
+
+    // ⚡ BOLT: Move intensity fluctuation logic inside useFrame with refs
+    // to avoid React re-renders while maintaining visual variety during meditation.
+    if (activo && t - lastIntensityUpdateRef.current > 2) {
+      const nuevo = intensidadRef.current + (Math.random() - 0.5) * 10;
+      intensidadRef.current = Math.max(30, Math.min(70, nuevo));
+      lastIntensityUpdateRef.current = t;
+
+      // Update material property directly, bypassing React reconciliation
+      material.emissiveIntensity = intensidadRef.current / 100;
+    }
 
     // Rotación suave basada en la frecuencia
     const velocidad = frecuencia / 10000;
     grupoRef.current.rotation.y += velocidad;
-    grupoRef.current.rotation.x = Math.sin(tiempo.current * 0.3) * 0.2;
+    grupoRef.current.rotation.x = Math.sin(t * 0.3) * 0.2;
 
-    // Pulsación basada en intensidad
-    const escala = 1 + Math.sin(tiempo.current * 2) * (intensidad / 200);
+    // Pulsación basada en intensidad (direct mutation via ref)
+    const escala = 1 + Math.sin(t * 2) * (intensidadRef.current / 200);
     grupoRef.current.scale.setScalar(escala);
   });
 
@@ -94,7 +110,7 @@ export function GeometriaSagrada3D({ frecuencia, intensidad, tipo }: GeometriaSa
       ))}
     </group>
   );
-}
+});
 
 interface GeoData {
   geometria: THREE.BufferGeometry;

--- a/components/3d/ParticulasCuanticas.tsx
+++ b/components/3d/ParticulasCuanticas.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useMemo } from "react";
+import { useRef, useMemo, memo } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
@@ -19,9 +19,21 @@ const COLORES_SOLFEGGIO: Record<number, { r: number; g: number; b: number }> = {
   852: { r: 0.51, g: 0.22, b: 0.93 }
 };
 
-export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuanticasProps) {
+export const ParticulasCuanticas = memo(function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuanticasProps) {
   const particulasRef = useRef<THREE.Points>(null);
   const tiempo = useRef(0);
+
+  // ⚡ BOLT: Pre-calculate trigonometric lookup tables to avoid O(n) Math.sin/cos calls per frame.
+  // This reduces trig operations in useFrame from 3000 to just 4 per frame.
+  const [sinTable, cosTable] = useMemo(() => {
+    const s = new Float32Array(cantidad);
+    const c = new Float32Array(cantidad);
+    for (let i = 0; i < cantidad; i++) {
+      s[i] = Math.sin(i);
+      c[i] = Math.cos(i);
+    }
+    return [s, c];
+  }, [cantidad]);
 
   const [posiciones, colores, tamaños] = useMemo(() => {
     const pos = new Float32Array(cantidad * 3);
@@ -56,8 +68,17 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
 
     tiempo.current += delta;
     const t = tiempo.current;
+    const t05 = t * 0.5;
     const velocidad = (frecuencia / 500) * delta;
     const posicionesArray = particulasRef.current.geometry.attributes.position.array as Float32Array;
+
+    // ⚡ BOLT: Use trigonometric identities to avoid expensive Math calls in the loop
+    // sin(t + i) = sin(t)cos(i) + cos(t)sin(i)
+    // cos(t + i) = cos(t)cos(i) - sin(t)sin(i)
+    const sinT = Math.sin(t);
+    const cosT = Math.cos(t);
+    const sinT05 = Math.sin(t05);
+    const cosT05 = Math.cos(t05);
 
     for (let i = 0; i < cantidad; i++) {
       const i3 = i * 3;
@@ -68,10 +89,16 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
 
       // ⚡ BOLT: Use local variables to avoid repeated TypedArray reads/writes
       // and squared distance to avoid Math.sqrt in the common case.
-      const phase = t + i;
-      const nextX = x + Math.sin(phase) * velocidad;
-      const nextY = y + Math.cos(phase) * velocidad;
-      const nextZ = z + Math.sin(t * 0.5 + i) * velocidad;
+      const si = sinTable[i];
+      const ci = cosTable[i];
+
+      const sinPhase = sinT * ci + cosT * si;
+      const cosPhase = cosT * ci - sinT * si;
+      const sinPhase05 = sinT05 * ci + cosT05 * si;
+
+      const nextX = x + sinPhase * velocidad;
+      const nextY = y + cosPhase * velocidad;
+      const nextZ = z + sinPhase05 * velocidad;
 
       const nextDistSq = nextX * nextX + nextY * nextY + nextZ * nextZ;
 
@@ -128,4 +155,4 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
       />
     </points>
   );
-}
+});

--- a/components/HistorySection.tsx
+++ b/components/HistorySection.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, memo, useMemo } from "react";
+import { CSSProperties, memo } from "react";
 
 const HISTORY_SECTION_STYLE: CSSProperties = { marginBottom: "1.5rem" };
 const LOG_CONTAINER_STYLE: CSSProperties = {


### PR DESCRIPTION
💡 **What:** 
- Memoized core 3D components (`GeometriaSagrada3D`, `ParticulasCuanticas`) and their container (`EscenaMeditacion3D`) using `React.memo` to skip expensive reconciliation.
- Refactored the "intensity" fluctuation logic from React state in `EscenaMeditacion3D` to an internal `useRef` and `useFrame` implementation in `GeometriaSagrada3D`.
- Optimized the particle system in `ParticulasCuanticas` by applying trigonometric expansion identities (`sin(a+b)`) and pre-calculating lookup tables for index-based phases.
- Fixed a React warning regarding mixed CSS shorthand/longhand properties in `app/page.tsx` and cleaned up unused imports/variables to ensure a clean production build.

🎯 **Why:** 
- Parent-level state updates (like the meditation timer) were forcing React to re-traverse the entire 3D component tree every second, which is a major performance bottleneck in R3F applications.
- The particle animation loop was performing 3,000 expensive `Math.sin`/`Math.cos` calls every frame, consuming unnecessary CPU cycles for deterministic oscillations.

📊 **Impact:** 
- **Zero re-renders** of the 3D scene during active meditation, even as timers update.
- **99.8% reduction** in trigonometric function calls within the particle animation loop (from 3,000 down to 4 calls per frame).
- Significantly reduced CPU scripting time and improved frame stability on mobile and lower-end hardware.

🔬 **Measurement:** 
- Verified using React Developer Tools "Highlight updates" that 3D components do not re-render during meditation.
- Confirmed a successful production build with `pnpm build` (addressing all strict linting/typing checks).
- Verified the animation still functions correctly through visual inspection and multi-frame screenshots.

---
*PR created automatically by Jules for task [6522249067706666466](https://jules.google.com/task/6522249067706666466) started by @mexicodxnmexico-create*