### PR TITLE
⚡ Bolt: Optimize particle trigonometry for high-frequency rendering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,7 @@
 ## 2025-06-24 - Efficient Fixed-Size Array Updates
 **Learning:** Using `[...arr, item].slice(-N)` for maintaining a fixed-size buffer causes two array allocations (one for the spread and one for the final slice). While `shift()` is O(n), using `slice()` followed by `push()` and `shift()` is significantly faster because it minimizes heap pressure by avoiding the intermediate array allocation.
 **Action:** Prefer `slice()` + `push()` + `shift()` for more efficient memory management in state transitions.
+
+## 2025-06-25 - Trigonometric Expansions in High-Frequency Loops
+**Learning:** Dense loops that perform phase-shifted trigonometric operations (`Math.sin(t + i)`, `Math.cos(t + i)`) inside a `requestAnimationFrame` loop cause considerable CPU load when dealing with thousands of particles.
+**Action:** Use trigonometric expansion identities (e.g. `sin(a+b) = sin(a)cos(b) + cos(a)sin(b)`). By pre-calculating the particle-specific constants (`sin(i)`, `cos(i)`) and computing the time-dependent constants (`sin(t)`, `cos(t)`) once per frame outside the loop, expensive `Math.sin`/`cos` calls are replaced by simple multiplication and addition, dramatically reducing frame calculation time.

--- a/components/3d/ParticulasCuanticas.tsx
+++ b/components/3d/ParticulasCuanticas.tsx
@@ -23,10 +23,12 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
   const particulasRef = useRef<THREE.Points>(null);
   const tiempo = useRef(0);
 
-  const [posiciones, colores, tamaños] = useMemo(() => {
+  const [posiciones, colores, tamaños, sinI, cosI] = useMemo(() => {
     const pos = new Float32Array(cantidad * 3);
     const col = new Float32Array(cantidad * 3);
     const tam = new Float32Array(cantidad);
+    const sI = new Float32Array(cantidad);
+    const cI = new Float32Array(cantidad);
 
     const colorBase = COLORES_SOLFEGGIO[frecuencia] || { r: 0.02, g: 0.84, b: 0.63 };
 
@@ -46,9 +48,13 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
       col[i3 + 2] = colorBase.b + (Math.random() - 0.5) * 0.2;
 
       tam[i] = Math.random() * 0.05 + 0.02;
+
+      // ⚡ BOLT: Pre-calculate sin/cos per particle for expansion identities
+      sI[i] = Math.sin(i);
+      cI[i] = Math.cos(i);
     }
 
-    return [pos, col, tam];
+    return [pos, col, tam, sI, cI];
   }, [cantidad, frecuencia]);
 
   useFrame((_state, delta) => {
@@ -59,6 +65,12 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
     const velocidad = (frecuencia / 500) * delta;
     const posicionesArray = particulasRef.current.geometry.attributes.position.array as Float32Array;
 
+    // ⚡ BOLT: Extract time-based trigonometry outside the particle loop
+    const sinT = Math.sin(t);
+    const cosT = Math.cos(t);
+    const sinT05 = Math.sin(t * 0.5);
+    const cosT05 = Math.cos(t * 0.5);
+
     for (let i = 0; i < cantidad; i++) {
       const i3 = i * 3;
 
@@ -68,10 +80,18 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
 
       // ⚡ BOLT: Use local variables to avoid repeated TypedArray reads/writes
       // and squared distance to avoid Math.sqrt in the common case.
-      const phase = t + i;
-      const nextX = x + Math.sin(phase) * velocidad;
-      const nextY = y + Math.cos(phase) * velocidad;
-      const nextZ = z + Math.sin(t * 0.5 + i) * velocidad;
+
+      // ⚡ BOLT: Apply trigonometric expansion identities to avoid per-particle Math.sin/cos calls
+      const s_i = sinI[i];
+      const c_i = cosI[i];
+
+      const sinPhase = sinT * c_i + cosT * s_i;       // sin(t+i)
+      const cosPhase = cosT * c_i - sinT * s_i;       // cos(t+i)
+      const sinPhase05 = sinT05 * c_i + cosT05 * s_i; // sin(t*0.5+i)
+
+      const nextX = x + sinPhase * velocidad;
+      const nextY = y + cosPhase * velocidad;
+      const nextZ = z + sinPhase05 * velocidad;
 
       const nextDistSq = nextX * nextX + nextY * nextY + nextZ * nextZ;
 


### PR DESCRIPTION
**💡 What:**
Optimized the rendering loop in `ParticulasCuanticas.tsx` by replacing the expensive `Math.sin(t + i)` and `Math.cos(t + i)` calls with their equivalent trigonometric expansion identities (`sin(a)cos(b) + cos(a)sin(b)`). The time-invariant particle properties (`sin(i)` and `cos(i)`) are now pre-calculated in a `useMemo` hook, and the time-dependent components are evaluated once per frame outside the particle loop.

**🎯 Why:**
Dense mathematical operations (like `Math.sin`) executed thousands of times per frame inside a `useFrame` hook cause significant CPU overhead and can lead to dropped frames on lower-end devices.

**📊 Impact:**
Reduces the number of trigonometric function evaluations from `O(3N)` to `O(1)` per frame (where N is the number of particles). By converting the inner loop strictly to arithmetic multiplication and addition, it dramatically lowers frame render time and CPU spikes.

**🔬 Measurement:**
Use Chrome DevTools Performance tab to profile the component when running. The total time spent in the `useFrame` callback for `ParticulasCuanticas` will be visibly lower. Tests passed using `npx tsx --test`.

---
*PR created automatically by Jules for task [3428651167780741794](https://jules.google.com/task/3428651167780741794) started by @mexicodxnmexico-create*