### PR TITLE
⚡ Bolt: Replace Math.sin/cos inside render loop with precomputed expansions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,7 @@
 ## 2025-06-24 - Efficient Fixed-Size Array Updates
 **Learning:** Using `[...arr, item].slice(-N)` for maintaining a fixed-size buffer causes two array allocations (one for the spread and one for the final slice). While `shift()` is O(n), using `slice()` followed by `push()` and `shift()` is significantly faster because it minimizes heap pressure by avoiding the intermediate array allocation.
 **Action:** Prefer `slice()` + `push()` + `shift()` for more efficient memory management in state transitions.
+
+## 2025-06-25 - Trigonometric Expansion for Animation Loops
+**Learning:** In Three.js animation loops involving phase-shifted oscillations (`sin(t + i)`), computing `Math.sin` or `Math.cos` for every particle (e.g., thousands of times per frame) introduces heavy CPU overhead. However, `t` is invariant across the loop for a single frame, and `i` is invariant across time.
+**Action:** Apply trigonometric expansion identities (e.g., `sin(a+b) = sin(a)cos(b) + cos(a)sin(b)`). Pre-calculate the particle-specific constants (`cos(i)`, `sin(i)`) in a `useMemo` lookup table and compute `sin(t)`, `cos(t)` once per frame outside the inner loop. This replaces thousands of expensive function calls with simple multiplication and addition, dramatically reducing frame time.

--- a/components/3d/ParticulasCuanticas.tsx
+++ b/components/3d/ParticulasCuanticas.tsx
@@ -23,10 +23,12 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
   const particulasRef = useRef<THREE.Points>(null);
   const tiempo = useRef(0);
 
-  const [posiciones, colores, tamaños] = useMemo(() => {
+  const [posiciones, colores, tamaños, cosI, sinI] = useMemo(() => {
     const pos = new Float32Array(cantidad * 3);
     const col = new Float32Array(cantidad * 3);
     const tam = new Float32Array(cantidad);
+    const cI = new Float32Array(cantidad);
+    const sI = new Float32Array(cantidad);
 
     const colorBase = COLORES_SOLFEGGIO[frecuencia] || { r: 0.02, g: 0.84, b: 0.63 };
 
@@ -46,9 +48,12 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
       col[i3 + 2] = colorBase.b + (Math.random() - 0.5) * 0.2;
 
       tam[i] = Math.random() * 0.05 + 0.02;
+
+      cI[i] = Math.cos(i);
+      sI[i] = Math.sin(i);
     }
 
-    return [pos, col, tam];
+    return [pos, col, tam, cI, sI];
   }, [cantidad, frecuencia]);
 
   useFrame((_state, delta) => {
@@ -59,6 +64,12 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
     const velocidad = (frecuencia / 500) * delta;
     const posicionesArray = particulasRef.current.geometry.attributes.position.array as Float32Array;
 
+    // ⚡ BOLT OPTIMIZATION: Extract invariant calculations outside the loop
+    const sinT = Math.sin(t);
+    const cosT = Math.cos(t);
+    const sinT05 = Math.sin(t * 0.5);
+    const cosT05 = Math.cos(t * 0.5);
+
     for (let i = 0; i < cantidad; i++) {
       const i3 = i * 3;
 
@@ -68,10 +79,15 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
 
       // ⚡ BOLT: Use local variables to avoid repeated TypedArray reads/writes
       // and squared distance to avoid Math.sqrt in the common case.
-      const phase = t + i;
-      const nextX = x + Math.sin(phase) * velocidad;
-      const nextY = y + Math.cos(phase) * velocidad;
-      const nextZ = z + Math.sin(t * 0.5 + i) * velocidad;
+      // ⚡ BOLT OPTIMIZATION: Replace expensive per-particle Math.sin/cos with arithmetic using pre-computed values
+      const c_i = cosI[i];
+      const s_i = sinI[i];
+      const sinPhase = sinT * c_i + cosT * s_i;
+      const cosPhase = cosT * c_i - sinT * s_i;
+      const sinPhase05 = sinT05 * c_i + cosT05 * s_i;
+      const nextX = x + sinPhase * velocidad;
+      const nextY = y + cosPhase * velocidad;
+      const nextZ = z + sinPhase05 * velocidad;
 
       const nextDistSq = nextX * nextX + nextY * nextY + nextZ * nextZ;
 


### PR DESCRIPTION
- 💡 What: Replacement of per-particle math calls with arithmetic precomputations.
- 🎯 Why: Optimize the `useFrame` 3D render loop inside `ParticulasCuanticas.tsx`.
- 📊 Impact: Substantial frame time reduction in the particle calculations.
- 🔬 Measurement: Execute test scripts and compare time using the precomputed method.

---
*PR created automatically by Jules for task [15246451652814828807](https://jules.google.com/task/15246451652814828807) started by @mexicodxnmexico-create*