### PR TITLE
🧪 Add explicit fractional rounding and undefined deviceorientation tests

### DIFF
--- a/tests/quantum-mirror.test.tsx
+++ b/tests/quantum-mirror.test.tsx
@@ -139,6 +139,38 @@ test('QuantumMirror deviceorientation logic', async (t) => {
     });
   });
 
+  await t.test('handles fractional beta rounding correctly', () => {
+    let root: TestRenderer.ReactTestRenderer | undefined;
+
+    TestRenderer.act(() => {
+      root = TestRenderer.create(<QuantumMirror />);
+    });
+
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 10.5, beta: 42.8, gamma: 15.3 });
+        });
+      }
+    });
+
+    const freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+    const alphaDiv = root!.root.findByProps({ 'data-testid': 'rotation-alpha' });
+    const betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
+    const gammaDiv = root!.root.findByProps({ 'data-testid': 'rotation-gamma' });
+
+    // 432 + Math.round(42.8 / 10) = 432 + Math.round(4.28) = 432 + 4 = 436
+    assert.strictEqual(freqDiv.children[0], '436');
+    assert.strictEqual(alphaDiv.children[0], '10.5');
+    assert.strictEqual(betaDiv.children[0], '42.8');
+    assert.strictEqual(gammaDiv.children[0], '15.3');
+
+    TestRenderer.act(() => {
+      root!.unmount();
+    });
+  });
+
   await t.test('handles missing event values gracefully', () => {
     let root: TestRenderer.ReactTestRenderer | undefined;
 
@@ -146,7 +178,7 @@ test('QuantumMirror deviceorientation logic', async (t) => {
       root = TestRenderer.create(<QuantumMirror />);
     });
 
-    // Dispatch mock deviceorientation event with null/undefined values
+    // Dispatch mock deviceorientation event with null values
     TestRenderer.act(() => {
       const orientationListeners = listeners['deviceorientation'];
       if (orientationListeners) {
@@ -160,6 +192,21 @@ test('QuantumMirror deviceorientation logic', async (t) => {
     const alphaDiv = root!.root.findByProps({ 'data-testid': 'rotation-alpha' });
     const betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
     const gammaDiv = root!.root.findByProps({ 'data-testid': 'rotation-gamma' });
+
+    assert.strictEqual(freqDiv.children[0], '432');
+    assert.strictEqual(alphaDiv.children[0], '0');
+    assert.strictEqual(betaDiv.children[0], '0');
+    assert.strictEqual(gammaDiv.children[0], '0');
+
+    // Dispatch mock deviceorientation event with undefined values
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: undefined, beta: undefined, gamma: undefined });
+        });
+      }
+    });
 
     assert.strictEqual(freqDiv.children[0], '432');
     assert.strictEqual(alphaDiv.children[0], '0');


### PR DESCRIPTION
🎯 **What:** Added tests to cover the core happy-path mathematical transformation for fractional beta values and gracefully handle explicitly `undefined` event properties in `deviceorientation` logic.
📊 **Coverage:** Now tests rounding functionality like `Math.round(42.8 / 10)` to yield the correct `436` base frequency, and covers scenarios where `DeviceOrientationEvent` fires with `undefined` rotational coordinates instead of `null`.
✨ **Result:** Enhanced test stability and guarantees coverage for edge cases explicitly requested, preventing future regressions.

---
*PR created automatically by Jules for task [18132820491309449144](https://jules.google.com/task/18132820491309449144) started by @mexicodxnmexico-create*