### PR TITLE
🎨 Palette: Replace structural elements with semantic labels

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-30 - Structural Elements as Labels
+**Learning:** This app frequently uses block-level structural elements like `<h3>` as pseudo-labels for form controls, which breaks screen reader association. Replacing them with `<label>` tags can cause visual regressions since labels are inline elements by default.
+**Action:** When converting structural elements to semantic `<label>` tags for accessibility, explicitly apply `display: 'block'` and `fontWeight: 'bold'` in the inline styles to maintain the original design layout.

--- a/components/meditacion/MeditacionAudioVisual3D.tsx
+++ b/components/meditacion/MeditacionAudioVisual3D.tsx
@@ -146,10 +146,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="frecuencia-select" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Frecuencia Solfeggio
-          </h3>
+          </label>
           <select
+            id="frecuencia-select"
             value={frecuenciaSeleccionada}
             onChange={(e) => setFrecuenciaSeleccionada(Number(e.target.value))}
             disabled={activo}
@@ -176,10 +177,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="geometria-select" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Geometría Sagrada
-          </h3>
+          </label>
           <select
+            id="geometria-select"
             value={geometriaSeleccionada}
             onChange={(e) => setGeometriaSeleccionada(e.target.value as any)}
             disabled={activo}
@@ -206,10 +208,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="duracion-input" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Duración (minutos)
-          </h3>
+          </label>
           <input
+            id="duracion-input"
             type="number"
             min="1"
             max="60"


### PR DESCRIPTION
💡 What: Replaced `<h3>` tags used as pseudo-labels for form controls (`<select>`, `<input>`) with semantic `<label>` tags. Linked them explicitly using `htmlFor` and `id` attributes.
🎯 Why: To improve screen reader accessibility by explicitly associating form controls with their descriptions, ensuring that assistive technologies can correctly announce them.
📸 Before/After: Visual layout maintained using explicit CSS (`display: 'block'`, `fontWeight: 'bold'`).
♿ Accessibility: Dramatically improved form control labeling, making the audio/visual meditation options fully understandable for users relying on screen readers.

---
*PR created automatically by Jules for task [13327952782466700158](https://jules.google.com/task/13327952782466700158) started by @mexicodxnmexico-create*