### PR TITLE
⚡ Bolt: Throttle deviceorientation events in QuantumMirror

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,7 @@
 ## 2025-06-24 - Efficient Fixed-Size Array Updates
 **Learning:** Using `[...arr, item].slice(-N)` for maintaining a fixed-size buffer causes two array allocations (one for the spread and one for the final slice). While `shift()` is O(n), using `slice()` followed by `push()` and `shift()` is significantly faster because it minimizes heap pressure by avoiding the intermediate array allocation.
 **Action:** Prefer `slice()` + `push()` + `shift()` for more efficient memory management in state transitions.
+
+## 2025-06-25 - DeviceOrientation Throttling
+**Learning:** Found that `QuantumMirror.tsx` was dispatching raw `deviceorientation` events directly into React state updates without any throttling. Since sensor events fire extremely fast (often 60+ Hz, sometimes >100 Hz depending on the device), this results in severe main thread blocking and unnecessary rapid re-renders.
+**Action:** Throttle the state update in the event listener using `requestAnimationFrame` and track pending frames with a `useRef`. This synchronizes updates with the device's display refresh rate (e.g. ~60fps) and drops unnecessary intermediate state updates.

--- a/src/components/QuantumMirror.tsx
+++ b/src/components/QuantumMirror.tsx
@@ -1,25 +1,36 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 
 export const QuantumMirror: React.FC = () => {
   const [rotation, setRotation] = useState({ alpha: 0, beta: 0, gamma: 0 });
   const [frequency, setFrequency] = useState(432);
+  const rafRef = useRef<number | null>(null);
 
   // 1. Lógica de Sensores y Frecuencia
   useEffect(() => {
     const handleOrientation = (e: DeviceOrientationEvent) => {
-      setRotation({
-        alpha: e.alpha || 0,
-        beta: e.beta || 0,
-        gamma: e.gamma || 0
+      // ⚡ BOLT OPTIMIZATION: Throttle deviceorientation events using requestAnimationFrame
+      // to synchronize with display refresh rate and minimize React re-renders.
+      if (rafRef.current) return;
+
+      rafRef.current = requestAnimationFrame(() => {
+        setRotation({
+          alpha: e.alpha || 0,
+          beta: e.beta || 0,
+          gamma: e.gamma || 0
+        });
+        // La frecuencia cambia sutilmente con la inclinación
+        setFrequency(432 + (e.beta ? Math.round(e.beta / 10) : 0));
+        rafRef.current = null;
       });
-      // La frecuencia cambia sutilmente con la inclinación
-      setFrequency(432 + (e.beta ? Math.round(e.beta / 10) : 0));
     };
 
     window.addEventListener('deviceorientation', handleOrientation);
 
     return () => {
       window.removeEventListener('deviceorientation', handleOrientation);
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current);
+      }
     };
   }, []);
 

--- a/tests/quantum-mirror.test.tsx
+++ b/tests/quantum-mirror.test.tsx
@@ -9,6 +9,16 @@ test('QuantumMirror deviceorientation logic', async (t) => {
   const listeners: Record<string, Function[]> = {};
 
   t.beforeEach(() => {
+    // Mock requestAnimationFrame and cancelAnimationFrame
+    global.requestAnimationFrame = (callback) => {
+      // Execute the callback synchronously to simplify testing.
+      // To ensure that assignment `rafRef.current = requestAnimationFrame()` finishes BEFORE
+      // the callback sets it to null, we schedule it as a microtask.
+      queueMicrotask(() => callback(0));
+      return 1;
+    };
+    global.cancelAnimationFrame = () => {};
+
     // Mock global window and its event listeners
     Object.defineProperty(global, 'window', {
       value: {
@@ -26,6 +36,10 @@ test('QuantumMirror deviceorientation logic', async (t) => {
   });
 
   t.afterEach(() => {
+    // Restore original requestAnimationFrame
+    delete (global as any).requestAnimationFrame;
+    delete (global as any).cancelAnimationFrame;
+
     // Restore original window
     Object.defineProperty(global, 'window', {
       value: originalWindow,
@@ -35,10 +49,10 @@ test('QuantumMirror deviceorientation logic', async (t) => {
     for (const key in listeners) delete listeners[key];
   });
 
-  await t.test('initializes with default frequency and rotation', () => {
+  await t.test('initializes with default frequency and rotation', async () => {
     let root: TestRenderer.ReactTestRenderer | undefined;
 
-    TestRenderer.act(() => {
+    await TestRenderer.act(async () => {
       root = TestRenderer.create(<QuantumMirror />);
     });
 
@@ -57,21 +71,22 @@ test('QuantumMirror deviceorientation logic', async (t) => {
     });
   });
 
-  await t.test('updates frequency and rotation when deviceorientation event is dispatched', () => {
+  await t.test('updates frequency and rotation when deviceorientation event is dispatched', async () => {
     let root: TestRenderer.ReactTestRenderer | undefined;
 
-    TestRenderer.act(() => {
+    await TestRenderer.act(async () => {
       root = TestRenderer.create(<QuantumMirror />);
     });
 
     // Dispatch mock deviceorientation event
-    TestRenderer.act(() => {
+    await TestRenderer.act(async () => {
       const orientationListeners = listeners['deviceorientation'];
       if (orientationListeners) {
         orientationListeners.forEach(listener => {
           listener({ alpha: 90, beta: 45, gamma: 180 });
         });
       }
+      await Promise.resolve(); // drain microtask queue
     });
 
     const freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
@@ -91,20 +106,21 @@ test('QuantumMirror deviceorientation logic', async (t) => {
   });
 
 
-  await t.test('handles negative and zero beta values correctly', () => {
+  await t.test('handles negative and zero beta values correctly', async () => {
     let root: TestRenderer.ReactTestRenderer | undefined;
 
-    TestRenderer.act(() => {
+    await TestRenderer.act(async () => {
       root = TestRenderer.create(<QuantumMirror />);
     });
 
-    TestRenderer.act(() => {
+    await TestRenderer.act(async () => {
       const orientationListeners = listeners['deviceorientation'];
       if (orientationListeners) {
         orientationListeners.forEach(listener => {
           listener({ alpha: 10, beta: -45, gamma: -10 });
         });
       }
+      await Promise.resolve();
     });
 
     const freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
@@ -119,13 +135,14 @@ test('QuantumMirror deviceorientation logic', async (t) => {
     assert.strictEqual(gammaDiv.children[0], '-10');
 
     // Dispatch another event with beta: 0
-    TestRenderer.act(() => {
+    await TestRenderer.act(async () => {
       const orientationListeners = listeners['deviceorientation'];
       if (orientationListeners) {
         orientationListeners.forEach(listener => {
           listener({ alpha: 20, beta: 0, gamma: 20 });
         });
       }
+      await Promise.resolve();
     });
 
     // 432 + Math.round(0 / 10) = 432
@@ -139,21 +156,22 @@ test('QuantumMirror deviceorientation logic', async (t) => {
     });
   });
 
-  await t.test('handles missing event values gracefully', () => {
+  await t.test('handles missing event values gracefully', async () => {
     let root: TestRenderer.ReactTestRenderer | undefined;
 
-    TestRenderer.act(() => {
+    await TestRenderer.act(async () => {
       root = TestRenderer.create(<QuantumMirror />);
     });
 
     // Dispatch mock deviceorientation event with null/undefined values
-    TestRenderer.act(() => {
+    await TestRenderer.act(async () => {
       const orientationListeners = listeners['deviceorientation'];
       if (orientationListeners) {
         orientationListeners.forEach(listener => {
           listener({ alpha: null, beta: null, gamma: null });
         });
       }
+      await Promise.resolve();
     });
 
     const freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
@@ -171,10 +189,10 @@ test('QuantumMirror deviceorientation logic', async (t) => {
     });
   });
 
-  await t.test('removes event listener on unmount', () => {
+  await t.test('removes event listener on unmount', async () => {
     let root: TestRenderer.ReactTestRenderer | undefined;
 
-    TestRenderer.act(() => {
+    await TestRenderer.act(async () => {
       root = TestRenderer.create(<QuantumMirror />);
     });
 


### PR DESCRIPTION
💡 **What**: Wrapped the state updates from the `deviceorientation` event listener in `src/components/QuantumMirror.tsx` inside a `requestAnimationFrame` callback. We track pending frames with a `useRef` to throttle the updates.

🎯 **Why**: Device orientation sensors can fire at a much higher frequency than the screen refresh rate (often 60-120+ Hz). Previously, each event directly triggered a React state update (`setRotation` and `setFrequency`), causing severe main-thread blocking and unnecessary re-renders. Throttling ensures we only calculate and render state changes when the browser is ready to paint a new frame.

📊 **Impact**: Massively reduces React rendering overhead and prevents main-thread stuttering when interacting with device orientation, converting $O(sensor\_hz)$ updates to a maximum of $O(display\_hz)$ updates (e.g. max ~60 updates per second).

🔬 **Measurement**: 
1. `npx tsx --test tests/quantum-mirror.test.tsx` confirms the logic remains correct under test.
2. Verified `npx eslint .` is clean.
3. Documented in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [12404936884384627931](https://jules.google.com/task/12404936884384627931) started by @mexicodxnmexico-create*