### PR TITLE
🧪 Add test for fractional beta values in QuantumMirror

### DIFF
--- a/tests/quantum-mirror.test.tsx
+++ b/tests/quantum-mirror.test.tsx
@@ -139,6 +139,55 @@ test('QuantumMirror deviceorientation logic', async (t) => {
     });
   });
 
+  await t.test('handles fractional beta values correctly (Math.round)', () => {
+    let root: TestRenderer.ReactTestRenderer | undefined;
+
+    TestRenderer.act(() => {
+      root = TestRenderer.create(<QuantumMirror />);
+    });
+
+    // Test rounding down
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 10, beta: 44.9, gamma: 10 });
+        });
+      }
+    });
+
+    const freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+    const alphaDiv = root!.root.findByProps({ 'data-testid': 'rotation-alpha' });
+    const betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
+    const gammaDiv = root!.root.findByProps({ 'data-testid': 'rotation-gamma' });
+
+    // 432 + Math.round(44.9 / 10) = 432 + Math.round(4.49) = 432 + 4 = 436
+    assert.strictEqual(freqDiv.children[0], '436');
+    assert.strictEqual(alphaDiv.children[0], '10');
+    assert.strictEqual(betaDiv.children[0], '44.9');
+    assert.strictEqual(gammaDiv.children[0], '10');
+
+    // Test rounding up
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 20, beta: 45.1, gamma: 20 });
+        });
+      }
+    });
+
+    // 432 + Math.round(45.1 / 10) = 432 + Math.round(4.51) = 432 + 5 = 437
+    assert.strictEqual(freqDiv.children[0], '437');
+    assert.strictEqual(alphaDiv.children[0], '20');
+    assert.strictEqual(betaDiv.children[0], '45.1');
+    assert.strictEqual(gammaDiv.children[0], '20');
+
+    TestRenderer.act(() => {
+      root!.unmount();
+    });
+  });
+
   await t.test('handles missing event values gracefully', () => {
     let root: TestRenderer.ReactTestRenderer | undefined;
 


### PR DESCRIPTION
🎯 **What:** Added comprehensive test coverage for fractional `beta` values dispatched during `deviceorientation` events in the `QuantumMirror` component.

📊 **Coverage:** The test logic now explicitly covers the mathematical transformation (`Math.round(e.beta / 10)`) handling for edge cases, specifically checking rounding down (e.g., `44.9` results in frequency `436`) and rounding up (e.g., `45.1` results in frequency `437`).

✨ **Result:** Improved test reliability, robustness, and confidence in the logic tracking sensors by effectively mocking window event listeners and correctly testing mathematical logic.

---
*PR created automatically by Jules for task [6960276063096988888](https://jules.google.com/task/6960276063096988888) started by @mexicodxnmexico-create*