### PR TITLE
🎨 Palette: Improve accessibility of meditation form controls with semantic labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-03-15 - Critical Error State Accessibility
 **Learning:** When a system enters a critical error or collapsed state that disables primary UI interactions, simply rendering the state is insufficient. It requires 'role="alert"' to announce the critical state and explicit focus shifting (via 'autoFocus' or 'useEffect' with 'useRef') to the primary recovery action to maintain accessibility.
 **Action:** Always add 'role="alert"' to error containers and explicitly shift focus to the recovery button or primary text when a disruptive error state mounts.
+
+## 2025-05-24 - Form Control Labels
+**Learning:** Using structural headings (like `<h3>`) above form elements (like `<select>` or `<input>`) instead of `<label>`s breaks accessibility because the text is not programmatically associated with the input for screen readers, and it breaks UX because users cannot click the text to focus the input.
+**Action:** Always use `<label>` elements with the `htmlFor` attribute correctly matched to the input's `id` to ensure proper programmatic association and click-to-focus behavior.

--- a/components/HistorySection.tsx
+++ b/components/HistorySection.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, memo, useMemo } from "react";
+import { CSSProperties, memo, } from "react";
 
 const HISTORY_SECTION_STYLE: CSSProperties = { marginBottom: "1.5rem" };
 const LOG_CONTAINER_STYLE: CSSProperties = {

--- a/components/meditacion/MeditacionAudioVisual3D.tsx
+++ b/components/meditacion/MeditacionAudioVisual3D.tsx
@@ -146,10 +146,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="frecuencia" style={{ display: "block", fontSize: "1rem", marginBottom: "1rem", color: "#333", fontWeight: "bold" }}>
             Frecuencia Solfeggio
-          </h3>
+          </label>
           <select
+            id="frecuencia"
             value={frecuenciaSeleccionada}
             onChange={(e) => setFrecuenciaSeleccionada(Number(e.target.value))}
             disabled={activo}
@@ -176,10 +177,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="geometria" style={{ display: "block", fontSize: "1rem", marginBottom: "1rem", color: "#333", fontWeight: "bold" }}>
             Geometría Sagrada
-          </h3>
+          </label>
           <select
+            id="geometria"
             value={geometriaSeleccionada}
             onChange={(e) => setGeometriaSeleccionada(e.target.value as any)}
             disabled={activo}
@@ -206,10 +208,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="duracion" style={{ display: "block", fontSize: "1rem", marginBottom: "1rem", color: "#333", fontWeight: "bold" }}>
             Duración (minutos)
-          </h3>
+          </label>
           <input
+            id="duracion"
             type="number"
             min="1"
             max="60"


### PR DESCRIPTION
### 💡 What
Replaced the `<h3>` elements acting as titles for the form controls in `MeditacionAudioVisual3D` with semantic `<label>` elements. The `<label>` elements use the `htmlFor` attribute matched with new `id` attributes on the `<select>` and `<input>` elements. Kept the existing visual styling by setting `display: "block"` and `fontWeight: "bold"` on the labels.

### 🎯 Why
Using headings (`<h3>`) above form elements instead of `<label>`s breaks accessibility because the text is not programmatically associated with the input for screen readers. It also degrades UX because users cannot click the text to focus the input. This change ensures proper programmatic association and click-to-focus behavior.

### 📸 Before/After
**Before:** Form control labels were `<h3>` elements. Clicking the text did nothing. Screen readers would announce the inputs without context.
**After:** Form control labels are `<label>` elements. Clicking the text correctly focuses the respective dropdown or number input. Screen readers now properly announce the input's purpose.

### ♿ Accessibility
- Added explicit programmatic association between form labels and inputs (`htmlFor` -> `id`), which is critical for screen reader users to understand the purpose of the form controls.

---
*PR created automatically by Jules for task [15689999377890409934](https://jules.google.com/task/15689999377890409934) started by @mexicodxnmexico-create*