### PR TITLE
🎨 Palette: Improve Form Accessibility in Meditación Cuántica

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Semantic Labels in Forms
+**Learning:** Found instances where `<h3>` tags were being used as visual-only titles for form elements without proper semantic association. This breaks screen reader accessibility since the input is orphaned from its description.
+**Action:** Always replace visual-only heading elements (like `<h3>`) that label form fields with semantic `<label>` tags. Ensure the `htmlFor` attribute on the label explicitly matches the `id` of the form control (`<select>`, `<input>`) and use `display: block` to preserve the visual layout.

--- a/components/meditacion/MeditacionAudioVisual3D.tsx
+++ b/components/meditacion/MeditacionAudioVisual3D.tsx
@@ -146,10 +146,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="frecuencia-select" style={{ display: "block", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Frecuencia Solfeggio
-          </h3>
+          </label>
           <select
+            id="frecuencia-select"
             value={frecuenciaSeleccionada}
             onChange={(e) => setFrecuenciaSeleccionada(Number(e.target.value))}
             disabled={activo}
@@ -176,10 +177,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="geometria-select" style={{ display: "block", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Geometría Sagrada
-          </h3>
+          </label>
           <select
+            id="geometria-select"
             value={geometriaSeleccionada}
             onChange={(e) => setGeometriaSeleccionada(e.target.value as any)}
             disabled={activo}
@@ -206,10 +208,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="duracion-input" style={{ display: "block", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Duración (minutos)
-          </h3>
+          </label>
           <input
+            id="duracion-input"
             type="number"
             min="1"
             max="60"


### PR DESCRIPTION
💡 **What:** Replaced non-semantic `<h3>` visual headings with proper `<label>` elements for the three main form controls (Frecuencia, Geometría, and Duración) in the `MeditacionAudioVisual3D` component. 

🎯 **Why:** Using `<h3>` tags as visual-only titles for form elements breaks screen reader accessibility, as the input fields are left orphaned without an associated accessible description. This change ensures screen readers correctly read the label when the user focuses on the form control.

📸 **Before/After:** The visual layout remains identical, as the previous inline styles were preserved and `display: "block"` was added to force the `<label>` elements to behave like block-level elements similar to the `<h3>` tags.

♿ **Accessibility:**
- Added `<label>` elements with `htmlFor` attributes perfectly matching the `id` of their respective `<select>` and `<input>` elements.
- Logged learning in `.Jules/palette.md` to establish the pattern of always using semantic `<label>` tags for form controls.

---
*PR created automatically by Jules for task [14869115306281984245](https://jules.google.com/task/14869115306281984245) started by @mexicodxnmexico-create*