### PR TITLE
⚡ Bolt: Optimize ParticulasCuanticas with trigonometric expansion

### DIFF
--- a/components/3d/ParticulasCuanticas.tsx
+++ b/components/3d/ParticulasCuanticas.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useMemo } from "react";
+import { useRef, useMemo, memo } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
@@ -19,16 +19,19 @@ const COLORES_SOLFEGGIO: Record<number, { r: number; g: number; b: number }> = {
   852: { r: 0.51, g: 0.22, b: 0.93 }
 };
 
-export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuanticasProps) {
+// ⚡ BOLT: Wrap in React.memo to prevent unnecessary re-renders when parent props change
+export const ParticulasCuanticas = memo(function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuanticasProps) {
   const particulasRef = useRef<THREE.Points>(null);
   const tiempo = useRef(0);
 
-  const [posiciones, colores, tamaños] = useMemo(() => {
+  // ⚡ BOLT: Decouple static attributes from dynamic ones.
+  // We pre-calculate trig lookups (sinI, cosI) to replace O(N) Math.sin/cos calls in useFrame
+  // with O(N) arithmetic using trigonometric addition identities.
+  const { positions, sizes, sinI, cosI } = useMemo(() => {
     const pos = new Float32Array(cantidad * 3);
-    const col = new Float32Array(cantidad * 3);
     const tam = new Float32Array(cantidad);
-
-    const colorBase = COLORES_SOLFEGGIO[frecuencia] || { r: 0.02, g: 0.84, b: 0.63 };
+    const sI = new Float32Array(cantidad);
+    const cI = new Float32Array(cantidad);
 
     for (let i = 0; i < cantidad; i++) {
       const i3 = i * 3;
@@ -41,14 +44,28 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
       pos[i3 + 1] = radio * Math.sin(phi) * Math.sin(theta);
       pos[i3 + 2] = radio * Math.cos(phi);
 
+      tam[i] = Math.random() * 0.05 + 0.02;
+
+      // Pre-calculate trig values for phase i
+      sI[i] = Math.sin(i);
+      cI[i] = Math.cos(i);
+    }
+
+    return { positions: pos, sizes: tam, sinI: sI, cosI: cI };
+  }, [cantidad]);
+
+  // ⚡ BOLT: Colors only depend on frequency and quantity, separate from static geometry
+  const colors = useMemo(() => {
+    const col = new Float32Array(cantidad * 3);
+    const colorBase = COLORES_SOLFEGGIO[frecuencia] || { r: 0.02, g: 0.84, b: 0.63 };
+
+    for (let i = 0; i < cantidad; i++) {
+      const i3 = i * 3;
       col[i3] = colorBase.r + (Math.random() - 0.5) * 0.2;
       col[i3 + 1] = colorBase.g + (Math.random() - 0.5) * 0.2;
       col[i3 + 2] = colorBase.b + (Math.random() - 0.5) * 0.2;
-
-      tam[i] = Math.random() * 0.05 + 0.02;
     }
-
-    return [pos, col, tam];
+    return col;
   }, [cantidad, frecuencia]);
 
   useFrame((_state, delta) => {
@@ -56,8 +73,15 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
 
     tiempo.current += delta;
     const t = tiempo.current;
+    const t05 = t * 0.5;
     const velocidad = (frecuencia / 500) * delta;
     const posicionesArray = particulasRef.current.geometry.attributes.position.array as Float32Array;
+
+    // ⚡ BOLT: Pre-calculate trig values for the current time once per frame
+    const sinT = Math.sin(t);
+    const cosT = Math.cos(t);
+    const sinT05 = Math.sin(t05);
+    const cosT05 = Math.cos(t05);
 
     for (let i = 0; i < cantidad; i++) {
       const i3 = i * 3;
@@ -66,12 +90,19 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
       const y = posicionesArray[i3 + 1];
       const z = posicionesArray[i3 + 2];
 
-      // ⚡ BOLT: Use local variables to avoid repeated TypedArray reads/writes
-      // and squared distance to avoid Math.sqrt in the common case.
-      const phase = t + i;
-      const nextX = x + Math.sin(phase) * velocidad;
-      const nextY = y + Math.cos(phase) * velocidad;
-      const nextZ = z + Math.sin(t * 0.5 + i) * velocidad;
+      const si = sinI[i];
+      const ci = cosI[i];
+
+      // ⚡ BOLT: Replace Math.sin(t + i) with trigonometric identity:
+      // sin(a + b) = sin(a)cos(b) + cos(a)sin(b)
+      // cos(a + b) = cos(a)cos(b) - sin(a)sin(b)
+      const sinPhase = sinT * ci + cosT * si;
+      const cosPhase = cosT * ci - sinT * si;
+      const sinPhase05 = sinT05 * ci + cosT05 * si;
+
+      const nextX = x + sinPhase * velocidad;
+      const nextY = y + cosPhase * velocidad;
+      const nextZ = z + sinPhase05 * velocidad;
 
       const nextDistSq = nextX * nextX + nextY * nextY + nextZ * nextZ;
 
@@ -101,19 +132,19 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
         <bufferAttribute
           attach="attributes-position"
           count={cantidad}
-          array={posiciones}
+          array={positions}
           itemSize={3}
         />
         <bufferAttribute
           attach="attributes-color"
           count={cantidad}
-          array={colores}
+          array={colors}
           itemSize={3}
         />
         <bufferAttribute
           attach="attributes-size"
           count={cantidad}
-          array={tamaños}
+          array={sizes}
           itemSize={1}
         />
       </bufferGeometry>
@@ -128,4 +159,4 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
       />
     </points>
   );
-}
+});


### PR DESCRIPTION
💡 What: Optimized the `ParticulasCuanticas` 3D component.
🎯 Why: The previous implementation performed O(N) transcendental function calls (`Math.sin`, `Math.cos`) per frame and re-randomized particle positions on every frequency change.
📊 Impact: 
  - Replaces ~3,000 per-frame trig calls with arithmetic (for 1,000 particles).
  - Eliminates position re-calculation when only frequency changes.
  - Reduces re-render overhead via memoization.
🔬 Measurement: Verified via static analysis of the logic and successful execution of the test suite.

---
*PR created automatically by Jules for task [10426362940941829926](https://jules.google.com/task/10426362940941829926) started by @mexicodxnmexico-create*