### PR TITLE
🧪 [Test Improvement] Add coverage for fractional deviceorientation beta rounding in QuantumMirror

### DIFF
--- a/tests/quantum-mirror.test.tsx
+++ b/tests/quantum-mirror.test.tsx
@@ -139,6 +139,52 @@ test('QuantumMirror deviceorientation logic', async (t) => {
     });
   });
 
+  await t.test('rounds fractional beta values correctly for frequency calculation', () => {
+    let root: TestRenderer.ReactTestRenderer | undefined;
+
+    TestRenderer.act(() => {
+      root = TestRenderer.create(<QuantumMirror />);
+    });
+
+    // Test rounding up (e.g., 45.6 / 10 = 4.56 -> rounds to 5)
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 10, beta: 45.6, gamma: 20 });
+        });
+      }
+    });
+
+    let freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+    let betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
+
+    // 432 + Math.round(45.6 / 10) = 432 + 5 = 437
+    assert.strictEqual(freqDiv.children[0], '437');
+    assert.strictEqual(betaDiv.children[0], '45.6');
+
+    // Test rounding down (e.g., 44.4 / 10 = 4.44 -> rounds to 4)
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 10, beta: 44.4, gamma: 20 });
+        });
+      }
+    });
+
+    freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+    betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
+
+    // 432 + Math.round(44.4 / 10) = 432 + 4 = 436
+    assert.strictEqual(freqDiv.children[0], '436');
+    assert.strictEqual(betaDiv.children[0], '44.4');
+
+    TestRenderer.act(() => {
+      root!.unmount();
+    });
+  });
+
   await t.test('handles missing event values gracefully', () => {
     let root: TestRenderer.ReactTestRenderer | undefined;
 


### PR DESCRIPTION
🎯 **What:** The `QuantumMirror` component's frequency is calculated based on the `deviceorientation` event's `beta` value using the logic `432 + (e.beta ? Math.round(e.beta / 10) : 0)`. The test suite lacked specific coverage verifying that fractional numbers produced by the sensor event were rounded correctly.

📊 **Coverage:** A new sub-test has been added to the `QuantumMirror deviceorientation logic` suite. It covers:
* Rounding up for fractional values (e.g., `45.6` correctly generates a frequency of `437`).
* Rounding down for fractional values (e.g., `44.4` correctly generates a frequency of `436`).

✨ **Result:** Test coverage for the core `deviceorientation` transformation logic in `QuantumMirror` is now more robust, ensuring the exact expected numerical outcomes and protecting against future regression in fractional event handling.

---
*PR created automatically by Jules for task [13778320669371242534](https://jules.google.com/task/13778320669371242534) started by @mexicodxnmexico-create*