### PR TITLE
🎨 Palette: Replace h3 titles with semantic labels in MeditacionAudioVisual3D

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-03-15 - Critical Error State Accessibility
 **Learning:** When a system enters a critical error or collapsed state that disables primary UI interactions, simply rendering the state is insufficient. It requires 'role="alert"' to announce the critical state and explicit focus shifting (via 'autoFocus' or 'useEffect' with 'useRef') to the primary recovery action to maintain accessibility.
 **Action:** Always add 'role="alert"' to error containers and explicitly shift focus to the recovery button or primary text when a disruptive error state mounts.
+
+## 2024-05-24 - Form Field Accessibility
+**Learning:** Using `<h3>` elements purely as visual titles for form fields (like `<select>` and `<input>`) breaks accessibility because screen readers cannot associate the title with the control.
+**Action:** Always replace visual `<h3>` headings above form fields with semantic `<label>` elements, explicitly linking them using the `htmlFor` and `id` attributes to ensure full accessibility.

--- a/components/HistorySection.tsx
+++ b/components/HistorySection.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, memo, useMemo } from "react";
+import { CSSProperties, memo } from "react";
 
 const HISTORY_SECTION_STYLE: CSSProperties = { marginBottom: "1.5rem" };
 const LOG_CONTAINER_STYLE: CSSProperties = {

--- a/components/meditacion/MeditacionAudioVisual3D.tsx
+++ b/components/meditacion/MeditacionAudioVisual3D.tsx
@@ -146,10 +146,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="frecuencia-select" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Frecuencia Solfeggio
-          </h3>
+          </label>
           <select
+            id="frecuencia-select"
             value={frecuenciaSeleccionada}
             onChange={(e) => setFrecuenciaSeleccionada(Number(e.target.value))}
             disabled={activo}
@@ -176,10 +177,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="geometria-select" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Geometría Sagrada
-          </h3>
+          </label>
           <select
+            id="geometria-select"
             value={geometriaSeleccionada}
             onChange={(e) => setGeometriaSeleccionada(e.target.value as any)}
             disabled={activo}
@@ -206,10 +208,11 @@ export const MeditacionAudioVisual3D = memo(function MeditacionAudioVisual3D({ o
           borderRadius: "12px",
           border: "1px solid #eaeaea"
         }}>
-          <h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
+          <label htmlFor="duracion-input" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
             Duración (minutos)
-          </h3>
+          </label>
           <input
+            id="duracion-input"
             type="number"
             min="1"
             max="60"


### PR DESCRIPTION
💡 **What**
Replaced non-semantic `<h3>` visual headings with semantic `<label>` elements for form inputs (`<select>` and `<input>`) in the `MeditacionAudioVisual3D` component. Explicitly linked the labels and inputs using `htmlFor` and `id` attributes. Additionally, updated the `.jules/palette.md` journal with this accessibility learning.

🎯 **Why**
Using `<h3>` elements purely for visual titling of form controls prevents screen readers from properly associating the title with the input field, creating an accessibility barrier. Replacing them with explicitly linked `<label>` elements ensures screen readers announce the input fields correctly without altering the visual design.

📸 **Before/After**
*Before:*
```tsx
<h3 style={{ fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
  Frecuencia Solfeggio
</h3>
<select ...>
```
*After:*
```tsx
<label htmlFor="frecuencia-select" style={{ display: "block", fontWeight: "bold", fontSize: "1rem", marginBottom: "1rem", color: "#333" }}>
  Frecuencia Solfeggio
</label>
<select id="frecuencia-select" ...>
```

♿ **Accessibility**
*   **WCAG 1.3.1 Info and Relationships:** Labels are now programmatically tied to their respective form elements.
*   **WCAG 3.3.2 Labels or Instructions:** Inputs now have accessible names via explicit labeling.
*   Preserved existing visual hierarchy and contrast by migrating styles seamlessly to the `<label>` blocks (`display: "block"`, `fontWeight: "bold"`).

---
*PR created automatically by Jules for task [17740661102121059936](https://jules.google.com/task/17740661102121059936) started by @mexicodxnmexico-create*