### PR TITLE
🧪 [testing improvement] Add test for QuantumMirror fractional beta values

### DIFF
--- a/tests/quantum-mirror.test.tsx
+++ b/tests/quantum-mirror.test.tsx
@@ -171,6 +171,47 @@ test('QuantumMirror deviceorientation logic', async (t) => {
     });
   });
 
+  await t.test('handles fractional beta values and rounds correctly', () => {
+    let root: TestRenderer.ReactTestRenderer | undefined;
+
+    TestRenderer.act(() => {
+      root = TestRenderer.create(<QuantumMirror />);
+    });
+
+    // Test rounding down: 44 / 10 = 4.4 -> 4
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 0, beta: 44, gamma: 0 });
+        });
+      }
+    });
+
+    const freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+    const betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
+
+    assert.strictEqual(freqDiv.children[0], '436'); // 432 + 4
+    assert.strictEqual(betaDiv.children[0], '44');
+
+    // Test rounding up: 45 / 10 = 4.5 -> 5
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 0, beta: 45, gamma: 0 });
+        });
+      }
+    });
+
+    assert.strictEqual(freqDiv.children[0], '437'); // 432 + 5
+    assert.strictEqual(betaDiv.children[0], '45');
+
+    TestRenderer.act(() => {
+      root!.unmount();
+    });
+  });
+
   await t.test('removes event listener on unmount', () => {
     let root: TestRenderer.ReactTestRenderer | undefined;
 


### PR DESCRIPTION
🎯 **What:** This PR addresses a testing gap in the `QuantumMirror` component by adding a specific test for the `deviceorientation` logic when handling fractional `beta` values.
📊 **Coverage:** The test coverage now explicitly includes scenarios where `e.beta` is a fractional number, verifying that `Math.round(e.beta / 10)` correctly handles both rounding down (e.g., `4.4` to `4`) and rounding up (e.g., `4.5` to `5`) and reflects these changes in the resulting `frequency` state.
✨ **Result:** Test coverage and reliability for `QuantumMirror.tsx` have been improved, ensuring the core mathematical transformation logic functions as expected across varying inputs.

---
*PR created automatically by Jules for task [8062642799523988843](https://jules.google.com/task/8062642799523988843) started by @mexicodxnmexico-create*