### PR TITLE
🧪 Add fractional beta rounding tests for QuantumMirror

### DIFF
--- a/tests/quantum-mirror.test.tsx
+++ b/tests/quantum-mirror.test.tsx
@@ -139,6 +139,52 @@ test('QuantumMirror deviceorientation logic', async (t) => {
     });
   });
 
+  await t.test('handles fractional beta values correctly', () => {
+    let root: TestRenderer.ReactTestRenderer | undefined;
+
+    TestRenderer.act(() => {
+      root = TestRenderer.create(<QuantumMirror />);
+    });
+
+    // Test rounding up: 45.4 / 10 = 4.54 -> rounds to 5
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 10, beta: 45.4, gamma: 10 });
+        });
+      }
+    });
+
+    let freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+    let betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
+
+    // 432 + 5 = 437
+    assert.strictEqual(freqDiv.children[0], '437');
+    assert.strictEqual(betaDiv.children[0], '45.4');
+
+    // Test rounding down: 44.4 / 10 = 4.44 -> rounds to 4
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 10, beta: 44.4, gamma: 10 });
+        });
+      }
+    });
+
+    freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+    betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
+
+    // 432 + 4 = 436
+    assert.strictEqual(freqDiv.children[0], '436');
+    assert.strictEqual(betaDiv.children[0], '44.4');
+
+    TestRenderer.act(() => {
+      root!.unmount();
+    });
+  });
+
   await t.test('handles missing event values gracefully', () => {
     let root: TestRenderer.ReactTestRenderer | undefined;
 


### PR DESCRIPTION
🎯 **What:** The testing gap for fractional `beta` values in the `QuantumMirror` `deviceorientation` event handler has been addressed. The component previously only tested whole number `beta` updates, missing coverage for the `Math.round(e.beta / 10)` fractional rounding logic.

📊 **Coverage:** A new test case explicitly dispatches `deviceorientation` events with fractional `beta` values (45.4 and 44.4) to verify that `Math.round` properly rounds up to 5 and down to 4 respectively, triggering correct frequency updates.

✨ **Result:** Test coverage for `src/components/QuantumMirror.tsx` is more comprehensive and verifies the logic handles real-world fractional sensor values correctly without failing or miscalculating the display frequency.

---
*PR created automatically by Jules for task [13322750699410206668](https://jules.google.com/task/13322750699410206668) started by @mexicodxnmexico-create*