### PR TITLE
⚡ Bolt: Optimize 3D particle trig calculations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,7 @@
 ## 2025-06-24 - Efficient Fixed-Size Array Updates
 **Learning:** Using `[...arr, item].slice(-N)` for maintaining a fixed-size buffer causes two array allocations (one for the spread and one for the final slice). While `shift()` is O(n), using `slice()` followed by `push()` and `shift()` is significantly faster because it minimizes heap pressure by avoiding the intermediate array allocation.
 **Action:** Prefer `slice()` + `push()` + `shift()` for more efficient memory management in state transitions.
+
+## 2025-06-25 - Trigonometric Loop Optimization
+**Learning:** Found that `ParticulasCuanticas.tsx` was performing thousands of per-particle `Math.sin(phase)` and `Math.cos(phase)` calls within a 1000-iteration `useFrame` render loop. Because `phase` was derived dynamically (`t + i`), `Math.sin/cos` could not be pre-calculated outside the loop directly.
+**Action:** Used the trigonometric addition formulas (`sin(t+i) = sin(t)cos(i) + cos(t)sin(i)`) to separate the dynamic time `t` from the static particle index `i`. Pre-calculate `sin(t)` and `cos(t)` exactly once per frame, and lookup pre-calculated `sin(i)` and `cos(i)` from static Float32Arrays. This reduces math function calls from ~3000 to just 4 per frame, dramatically improving framerate. Additionally, decoupling `posiciones` and `colores` in `useMemo` avoids particle position resets when only frequency changes.

--- a/components/3d/ParticulasCuanticas.tsx
+++ b/components/3d/ParticulasCuanticas.tsx
@@ -23,12 +23,13 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
   const particulasRef = useRef<THREE.Points>(null);
   const tiempo = useRef(0);
 
-  const [posiciones, colores, tamaños] = useMemo(() => {
+  // ⚡ BOLT: Decouple static geometry attributes from dynamic ones (like color/frecuencia)
+  // This prevents resetting particle positions and visual jarring when frequency changes.
+  const [posiciones, tamaños, sinI, cosI] = useMemo(() => {
     const pos = new Float32Array(cantidad * 3);
-    const col = new Float32Array(cantidad * 3);
     const tam = new Float32Array(cantidad);
-
-    const colorBase = COLORES_SOLFEGGIO[frecuencia] || { r: 0.02, g: 0.84, b: 0.63 };
+    const sI = new Float32Array(cantidad);
+    const cI = new Float32Array(cantidad);
 
     for (let i = 0; i < cantidad; i++) {
       const i3 = i * 3;
@@ -41,14 +42,29 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
       pos[i3 + 1] = radio * Math.sin(phi) * Math.sin(theta);
       pos[i3 + 2] = radio * Math.cos(phi);
 
+      tam[i] = Math.random() * 0.05 + 0.02;
+
+      // Pre-calculate trig identities for the loop optimization
+      sI[i] = Math.sin(i);
+      cI[i] = Math.cos(i);
+    }
+
+    return [pos, tam, sI, cI];
+  }, [cantidad]); // Solo depende de la cantidad
+
+  // ⚡ BOLT: Separated color recalculation so it runs only when frequency/cantidad changes
+  const colores = useMemo(() => {
+    const col = new Float32Array(cantidad * 3);
+    const colorBase = COLORES_SOLFEGGIO[frecuencia] || { r: 0.02, g: 0.84, b: 0.63 };
+
+    for (let i = 0; i < cantidad; i++) {
+      const i3 = i * 3;
       col[i3] = colorBase.r + (Math.random() - 0.5) * 0.2;
       col[i3 + 1] = colorBase.g + (Math.random() - 0.5) * 0.2;
       col[i3 + 2] = colorBase.b + (Math.random() - 0.5) * 0.2;
-
-      tam[i] = Math.random() * 0.05 + 0.02;
     }
 
-    return [pos, col, tam];
+    return col;
   }, [cantidad, frecuencia]);
 
   useFrame((_state, delta) => {
@@ -56,8 +72,16 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
 
     tiempo.current += delta;
     const t = tiempo.current;
+    const tHalf = t * 0.5;
     const velocidad = (frecuencia / 500) * delta;
     const posicionesArray = particulasRef.current.geometry.attributes.position.array as Float32Array;
+
+    // ⚡ BOLT: Pre-calculate trig identities for 't' outside the loop
+    // Reduces Math.sin/cos calls from ~3000 to just 4 per frame
+    const sinT = Math.sin(t);
+    const cosT = Math.cos(t);
+    const sinTHalf = Math.sin(tHalf);
+    const cosTHalf = Math.cos(tHalf);
 
     for (let i = 0; i < cantidad; i++) {
       const i3 = i * 3;
@@ -66,12 +90,16 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
       const y = posicionesArray[i3 + 1];
       const z = posicionesArray[i3 + 2];
 
-      // ⚡ BOLT: Use local variables to avoid repeated TypedArray reads/writes
-      // and squared distance to avoid Math.sqrt in the common case.
-      const phase = t + i;
-      const nextX = x + Math.sin(phase) * velocidad;
-      const nextY = y + Math.cos(phase) * velocidad;
-      const nextZ = z + Math.sin(t * 0.5 + i) * velocidad;
+      // ⚡ BOLT: Use pre-computed lookups and trigonometric addition formulas:
+      // sin(t + i) = sin(t)cos(i) + cos(t)sin(i)
+      // cos(t + i) = cos(t)cos(i) - sin(t)sin(i)
+      const sinPhase = sinT * cosI[i] + cosT * sinI[i];
+      const cosPhase = cosT * cosI[i] - sinT * sinI[i];
+      const sinPhaseZ = sinTHalf * cosI[i] + cosTHalf * sinI[i];
+
+      const nextX = x + sinPhase * velocidad;
+      const nextY = y + cosPhase * velocidad;
+      const nextZ = z + sinPhaseZ * velocidad;
 
       const nextDistSq = nextX * nextX + nextY * nextY + nextZ * nextZ;
 

--- a/components/HistorySection.tsx
+++ b/components/HistorySection.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, memo, useMemo } from "react";
+import { CSSProperties, memo} from "react";
 
 const HISTORY_SECTION_STYLE: CSSProperties = { marginBottom: "1.5rem" };
 const LOG_CONTAINER_STYLE: CSSProperties = {


### PR DESCRIPTION
💡 **What:** 
- Decoupled `useMemo` hooks in `ParticulasCuanticas.tsx` to separate static properties (positions, sizes, pre-calculated `sinI`, `cosI`) from dynamic ones (colors dependent on `frecuencia`). 
- Replaced expensive per-particle `Math.sin(phase)` and `Math.cos(phase)` calls within the `useFrame` loop with simple lookups and trigonometric addition formulas (`sin(t+i) = sin(t)cos(i) + cos(t)sin(i)`).

🎯 **Why:** 
Calling `Math.sin` and `Math.cos` thousands of times per frame in a tight WebGL render loop causes significant CPU bottlenecking and frame drops. Furthermore, tying the `posiciones` and `colores` `useMemo` hooks together caused jarring UI resets where particles changed positions whenever the `frecuencia` was updated.

📊 **Impact:** 
- Reduces `Math.sin`/`Math.cos` function calls in `ParticulasCuanticas.tsx` from ~3000 per frame to just 4 per frame.
- Avoids full particle position recalculation (saving ~3000 iterations and array allocations) when only the frequency color needs to change.

🔬 **Measurement:** 
- Start `pnpm run dev` and navigate to "Meditación 3D".
- Click "Iniciar Meditación Cuántica" to render the 3D scene with 1000 particles.
- Profile with React DevTools and browser Performance tab; observe significantly lower main-thread CPU usage and higher framerates compared to before the patch.
- Change the "Frecuencia Solfeggio" dropdown while meditating; verify that the particles transition color smoothly without randomly jumping to new positions.

---
*PR created automatically by Jules for task [8761549478140908183](https://jules.google.com/task/8761549478140908183) started by @mexicodxnmexico-create*