### PR TITLE
🧪 Add test for QuantumMirror deviceorientation 0 values

### DIFF
--- a/tests/quantum-mirror.test.tsx
+++ b/tests/quantum-mirror.test.tsx
@@ -139,6 +139,38 @@ test('QuantumMirror deviceorientation logic', async (t) => {
     });
   });
 
+  await t.test('handles exact zero values correctly', () => {
+    let root: TestRenderer.ReactTestRenderer | undefined;
+
+    TestRenderer.act(() => {
+      root = TestRenderer.create(<QuantumMirror />);
+    });
+
+    // Dispatch mock deviceorientation event with 0 values
+    TestRenderer.act(() => {
+      const orientationListeners = listeners['deviceorientation'];
+      if (orientationListeners) {
+        orientationListeners.forEach(listener => {
+          listener({ alpha: 0, beta: 0, gamma: 0 });
+        });
+      }
+    });
+
+    const freqDiv = root!.root.findByProps({ 'data-testid': 'frequency' });
+    const alphaDiv = root!.root.findByProps({ 'data-testid': 'rotation-alpha' });
+    const betaDiv = root!.root.findByProps({ 'data-testid': 'rotation-beta' });
+    const gammaDiv = root!.root.findByProps({ 'data-testid': 'rotation-gamma' });
+
+    assert.strictEqual(freqDiv.children[0], '432');
+    assert.strictEqual(alphaDiv.children[0], '0');
+    assert.strictEqual(betaDiv.children[0], '0');
+    assert.strictEqual(gammaDiv.children[0], '0');
+
+    TestRenderer.act(() => {
+      root!.unmount();
+    });
+  });
+
   await t.test('handles missing event values gracefully', () => {
     let root: TestRenderer.ReactTestRenderer | undefined;
 


### PR DESCRIPTION
🎯 **What:** The component `QuantumMirror` lacked an explicit test case to handle exact `0` values from the `deviceorientation` event, which could fall back improperly or mask issues with the falsy boolean logic on `e.beta || 0` and similar fields.
📊 **Coverage:** A test suite case now verifies when all 3 values (alpha, beta, gamma) are exactly `0`, and confirms that the defaults gracefully assign correctly without triggering weird state mutations.
✨ **Result:** Enhanced test coverage that explicitly catches logic breakdowns on `e.beta ? Math.round(e.beta / 10) : 0` and standardizes expected behavior.

---
*PR created automatically by Jules for task [5076499265109423639](https://jules.google.com/task/5076499265109423639) started by @mexicodxnmexico-create*