### PR TITLE
⚡ Bolt: Optimize Trig rendering and calculations in ParticulasCuanticas

### DIFF
--- a/components/3d/ParticulasCuanticas.tsx
+++ b/components/3d/ParticulasCuanticas.tsx
@@ -23,16 +23,16 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
   const particulasRef = useRef<THREE.Points>(null);
   const tiempo = useRef(0);
 
-  const [posiciones, colores, tamaños] = useMemo(() => {
+  // ⚡ BOLT: Decouple static attributes from dynamic ones and precompute trig lookups
+  // This prevents re-randomizing positions when only frequency changes
+  const [posiciones, tamaños, sinLookup, cosLookup] = useMemo(() => {
     const pos = new Float32Array(cantidad * 3);
-    const col = new Float32Array(cantidad * 3);
     const tam = new Float32Array(cantidad);
-
-    const colorBase = COLORES_SOLFEGGIO[frecuencia] || { r: 0.02, g: 0.84, b: 0.63 };
+    const sinL = new Float32Array(cantidad);
+    const cosL = new Float32Array(cantidad);
 
     for (let i = 0; i < cantidad; i++) {
       const i3 = i * 3;
-
       const radio = Math.random() * 5 + 3;
       const theta = Math.random() * Math.PI * 2;
       const phi = Math.random() * Math.PI;
@@ -41,14 +41,26 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
       pos[i3 + 1] = radio * Math.sin(phi) * Math.sin(theta);
       pos[i3 + 2] = radio * Math.cos(phi);
 
+      tam[i] = Math.random() * 0.05 + 0.02;
+      sinL[i] = Math.sin(i);
+      cosL[i] = Math.cos(i);
+    }
+
+    return [pos, tam, sinL, cosL];
+  }, [cantidad]);
+
+  // Only recompute colors when frequency or quantity changes
+  const colores = useMemo(() => {
+    const col = new Float32Array(cantidad * 3);
+    const colorBase = COLORES_SOLFEGGIO[frecuencia] || { r: 0.02, g: 0.84, b: 0.63 };
+
+    for (let i = 0; i < cantidad; i++) {
+      const i3 = i * 3;
       col[i3] = colorBase.r + (Math.random() - 0.5) * 0.2;
       col[i3 + 1] = colorBase.g + (Math.random() - 0.5) * 0.2;
       col[i3 + 2] = colorBase.b + (Math.random() - 0.5) * 0.2;
-
-      tam[i] = Math.random() * 0.05 + 0.02;
     }
-
-    return [pos, col, tam];
+    return col;
   }, [cantidad, frecuencia]);
 
   useFrame((_state, delta) => {
@@ -59,6 +71,15 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
     const velocidad = (frecuencia / 500) * delta;
     const posicionesArray = particulasRef.current.geometry.attributes.position.array as Float32Array;
 
+    // ⚡ BOLT: Pre-calculate common trig values for the frame to replace per-particle Math.sin/cos
+    // sin(t + i) = sin(t)cos(i) + cos(t)sin(i)
+    // cos(t + i) = cos(t)cos(i) - sin(t)sin(i)
+    // sin(t * 0.5 + i) = sin(t * 0.5)cos(i) + cos(t * 0.5)sin(i)
+    const sinT = Math.sin(t);
+    const cosT = Math.cos(t);
+    const sinT05 = Math.sin(t * 0.5);
+    const cosT05 = Math.cos(t * 0.5);
+
     for (let i = 0; i < cantidad; i++) {
       const i3 = i * 3;
 
@@ -66,12 +87,17 @@ export function ParticulasCuanticas({ frecuencia, cantidad }: ParticulasCuantica
       const y = posicionesArray[i3 + 1];
       const z = posicionesArray[i3 + 2];
 
-      // ⚡ BOLT: Use local variables to avoid repeated TypedArray reads/writes
-      // and squared distance to avoid Math.sqrt in the common case.
-      const phase = t + i;
-      const nextX = x + Math.sin(phase) * velocidad;
-      const nextY = y + Math.cos(phase) * velocidad;
-      const nextZ = z + Math.sin(t * 0.5 + i) * velocidad;
+      const sinI = sinLookup[i];
+      const cosI = cosLookup[i];
+
+      // ⚡ BOLT: Replace per-particle Math.sin/Math.cos with arithmetic expansions
+      const sinPhase = sinT * cosI + cosT * sinI;
+      const cosPhase = cosT * cosI - sinT * sinI;
+      const sinPhaseZ = sinT05 * cosI + cosT05 * sinI;
+
+      const nextX = x + sinPhase * velocidad;
+      const nextY = y + cosPhase * velocidad;
+      const nextZ = z + sinPhaseZ * velocidad;
 
       const nextDistSq = nextX * nextX + nextY * nextY + nextZ * nextZ;
 


### PR DESCRIPTION
💡 **What:**
1. Decoupled static attributes (`posiciones`, `tamaños`, precomputed trig lookups) from dynamic attributes (`colores`) into two separate `useMemo` hooks.
2. Replaced the extremely expensive `Math.sin` and `Math.cos` calls executed inside the per-particle `useFrame` render loop with simple arithmetic leveraging precomputed `sin(i)` and `cos(i)` values and trigonometric expansion identities (e.g. `sin(t+i) = sin(t)cos(i) + cos(t)sin(i)`).

🎯 **Why:**
1. Previously, changing the frequency (which controls the particle speed and color) caused the static buffer (containing `posiciones` and `tamaños`) to be completely re-randomized because they shared a `useMemo` block. This forced a costly reallocation and caused the particle field to visually jump. 
2. Invoking heavy standard library trigonometric functions like `Math.sin` and `Math.cos` tens of thousands of times per second strictly limits the simulation's scale and causes noticeable thermal throttling/battery drain on mobile graphics.

📊 **Impact:**
- Significantly reduces the CPU overhead required to calculate the animation per frame, leading to vastly improved frame consistency and lower device power draw.
- Eliminates "jarring" visual teleports of particles when frequency or speed changes during the simulation.

🔬 **Measurement:**
- Run `pnpm dev`, open the simulation, and observe frame times in Chrome DevTools using the Performance panel before and after. Frame time consistency should tighten considerably, with fewer dropped frames under high simulation stress.
- Toggle different Solfeggio frequencies and observe that the particle geometry does not abruptly change.

---
*PR created automatically by Jules for task [14869161754014681122](https://jules.google.com/task/14869161754014681122) started by @mexicodxnmexico-create*